### PR TITLE
small fix. fix the properties  to include keys  and the single value key  as an …

### DIFF
--- a/src/services/notionQuizService.ts
+++ b/src/services/notionQuizService.ts
@@ -59,7 +59,7 @@ class NotionQuizService {
       // 4. Invoke quiz generator Lambda with S3 location
       const jobId = await invokeQuizGenerator({
         bucket: s3BucketName,
-        key,
+        keys: [key],
         userId: input.userId,
         title: input.title,
         userInstructions: input.userInstructions,


### PR DESCRIPTION
The app was crashing as the properties in the payload (QuizGeneratePayload) expect the key "keys" as a string array. Fixed to include the property and the key value as a string array