### PR TITLE
feat: add GET /analytics/summary endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { swaggerSpec } from './config/swagger'
 import { errorHandler } from './middlewares/errorHandler'
 import { handleMulterError } from './middlewares/multerUpload'
 import { notFoundHandler } from './middlewares/notFound'
+import analyticsRoutes from './routes/analytics.routes'
 import authRoutes from './routes/auth.routes'
 import byokRoutes from './routes/byok.routes'
 import healthRoutes from './routes/health.routes'
@@ -38,6 +39,7 @@ app.use(healthRoutes)
 app.use(uploadRoutes)
 app.use(quizRoutes)
 app.use(byokRoutes)
+app.use(analyticsRoutes)
 
 app.use(handleMulterError)
 app.use(notFoundHandler)

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -25,6 +25,13 @@ const options: swaggerJSDoc.Options = {
       { name: 'Analytics', description: 'User quiz analytics' },
     ],
     components: {
+      securitySchemes: {
+        cookieAuth: {
+          type: 'apiKey',
+          in: 'cookie',
+          name: 'accessToken',
+        },
+      },
       schemas: {
         ApiSuccessResponse: {
           type: 'object',

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -22,6 +22,7 @@ const options: swaggerJSDoc.Options = {
       { name: 'Health', description: 'Health and readiness checks' },
       { name: 'Upload', description: 'File upload APIs' },
       { name: 'Quiz', description: 'Quiz generation and CRUD APIs' },
+      { name: 'Analytics', description: 'User quiz analytics' },
     ],
     components: {
       schemas: {
@@ -81,7 +82,10 @@ const options: swaggerJSDoc.Options = {
       },
     },
   },
-  apis: [path.join(__dirname, '../app.ts'), path.join(__dirname, '../routes/*.ts')],
+  apis: [
+    path.join(__dirname, '../app.ts').replace(/\\/g, '/'),
+    path.join(__dirname, '../routes/*.ts').replace(/\\/g, '/'),
+  ],
 }
 
 export const swaggerSpec = swaggerJSDoc(options)

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -84,7 +84,9 @@ const options: swaggerJSDoc.Options = {
   },
   apis: [
     path.join(__dirname, '../app.ts').replace(/\\/g, '/'),
+    path.join(__dirname, '../app.js').replace(/\\/g, '/'),
     path.join(__dirname, '../routes/*.ts').replace(/\\/g, '/'),
+    path.join(__dirname, '../routes/*.js').replace(/\\/g, '/'),
   ],
 }
 

--- a/src/controllers/analyticsController.ts
+++ b/src/controllers/analyticsController.ts
@@ -1,0 +1,19 @@
+import type { NextFunction, Request, Response } from 'express'
+
+import { successResponse } from '../helpers/apiResponse'
+import { getAuthUserId } from '../helpers/utils/authUtils'
+import { getAnalyticsSummary } from '../services/analytics.service'
+
+export const getAnalyticsSummaryController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const userId = getAuthUserId(req)
+    const summary = await getAnalyticsSummary(userId)
+    res.status(200).json(successResponse('Analytics summary retrieved', summary))
+  } catch (error) {
+    next(error)
+  }
+}

--- a/src/routes/analytics.routes.ts
+++ b/src/routes/analytics.routes.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express'
+
+import { getAnalyticsSummaryController } from '../controllers/analyticsController'
+import { authMiddleware } from '../middlewares/authMiddleware'
+
+const router = Router()
+
+/**
+ * @openapi
+ * /analytics/summary:
+ *   get:
+ *     tags:
+ *       - Analytics
+ *     security:
+ *       - cookieAuth: []
+ *     summary: Aggregate quiz analytics for the authenticated user
+ *     responses:
+ *       200:
+ *         description: Analytics summary retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiSuccessResponse'
+ *       401:
+ *         description: Not authenticated
+ */
+router.get('/analytics/summary', authMiddleware, getAnalyticsSummaryController)
+
+export default router

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -47,36 +47,41 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     }
   }
 
-  const gradedRows = rows.filter((r) => r.totalQuestions > 0)
-
-  const averageScore = gradedRows.length
-    ? gradedRows.reduce((sum, r) => sum + toPercent(r.correctAnswers, r.totalQuestions), 0) /
-      gradedRows.length
-    : 0
-
+  let gradedScoreSum = 0
+  let gradedCount = 0
   const byDay = new Map<string, { sum: number; count: number }>()
-  for (const r of gradedRows) {
+  const byType = new Map<QuestionType, { sum: number; count: number }>()
+
+  for (const r of rows) {
+    if (r.totalQuestions <= 0) continue
+
+    const percent = toPercent(r.correctAnswers, r.totalQuestions)
+    gradedScoreSum += percent
+    gradedCount += 1
+
     const y = r.createdAt.getFullYear()
     const m = String(r.createdAt.getMonth() + 1).padStart(2, '0')
     const d = String(r.createdAt.getDate()).padStart(2, '0')
     const date = `${y}-${m}-${d}`
-    const entry = byDay.get(date) ?? { sum: 0, count: 0 }
-    entry.sum += toPercent(r.correctAnswers, r.totalQuestions)
-    entry.count += 1
-    byDay.set(date, entry)
+    const dayEntry = byDay.get(date) ?? { sum: 0, count: 0 }
+    dayEntry.sum += percent
+    dayEntry.count += 1
+    byDay.set(date, dayEntry)
+
+    if (r.quizType) {
+      const typeEntry = byType.get(r.quizType) ?? { sum: 0, count: 0 }
+      typeEntry.sum += percent
+      typeEntry.count += 1
+      byType.set(r.quizType, typeEntry)
+    }
   }
+
+  const averageScore = gradedCount > 0 ? gradedScoreSum / gradedCount : 0
+
   const scoreOverTime: ScorePoint[] = Array.from(byDay.entries())
     .map(([date, { sum, count }]) => ({ date, score: round(sum / count) }))
     .sort((a, b) => a.date.localeCompare(b.date))
 
-  const byType = new Map<QuestionType, { sum: number; count: number }>()
-  for (const r of gradedRows) {
-    if (!r.quizType) continue
-    const entry = byType.get(r.quizType) ?? { sum: 0, count: 0 }
-    entry.sum += toPercent(r.correctAnswers, r.totalQuestions)
-    entry.count += 1
-    byType.set(r.quizType, entry)
-  }
   const breakdownByType: TypeBreakdown[] = Array.from(byType.entries()).map(
     ([type, { sum, count }]) => ({
       type,

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -1,0 +1,91 @@
+import { eq } from 'drizzle-orm'
+
+import { db } from '../database/database'
+import { quizResults, quizzes } from '../database/schema'
+import type { QuestionType } from '../types/questionTypes'
+
+export type ScorePoint = {
+  date: string
+  score: number
+}
+
+export type TypeBreakdown = {
+  type: QuestionType
+  quizCount: number
+  averageScore: number
+}
+
+export type AnalyticsSummary = {
+  totalQuizzesTaken: number
+  averageScore: number
+  scoreOverTime: ScorePoint[]
+  breakdownByType: TypeBreakdown[]
+}
+
+const toPercent = (correct: number, total: number) => (total > 0 ? (correct / total) * 100 : 0)
+
+const round = (n: number) => Math.round(n * 100) / 100
+
+export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSummary> => {
+  const rows = await db
+    .select({
+      createdAt: quizResults.createdAt,
+      totalQuestions: quizResults.totalQuestions,
+      correctAnswers: quizResults.correctAnswers,
+      quizType: quizzes.type,
+    })
+    .from(quizResults)
+    .innerJoin(quizzes, eq(quizResults.quizId, quizzes.id))
+    .where(eq(quizResults.userId, userId))
+
+  if (rows.length === 0) {
+    return {
+      totalQuizzesTaken: 0,
+      averageScore: 0,
+      scoreOverTime: [],
+      breakdownByType: [],
+    }
+  }
+
+  const gradedRows = rows.filter((r) => r.totalQuestions > 0)
+
+  const averageScore = gradedRows.length
+    ? gradedRows.reduce((sum, r) => sum + toPercent(r.correctAnswers, r.totalQuestions), 0) /
+      gradedRows.length
+    : 0
+
+  const byDay = new Map<string, { sum: number; count: number }>()
+  for (const r of gradedRows) {
+    const date = r.createdAt.toISOString().slice(0, 10)
+    const entry = byDay.get(date) ?? { sum: 0, count: 0 }
+    entry.sum += toPercent(r.correctAnswers, r.totalQuestions)
+    entry.count += 1
+    byDay.set(date, entry)
+  }
+  const scoreOverTime: ScorePoint[] = Array.from(byDay.entries())
+    .map(([date, { sum, count }]) => ({ date, score: round(sum / count) }))
+    .sort((a, b) => a.date.localeCompare(b.date))
+
+  const byType = new Map<QuestionType, { sum: number; count: number }>()
+  for (const r of gradedRows) {
+    if (!r.quizType) continue
+    const entry = byType.get(r.quizType) ?? { sum: 0, count: 0 }
+    entry.sum += toPercent(r.correctAnswers, r.totalQuestions)
+    entry.count += 1
+    byType.set(r.quizType, entry)
+  }
+  const breakdownByType: TypeBreakdown[] = Array.from(byType.entries()).map(
+    ([type, { sum, count }]) => ({
+      type,
+      quizCount: count,
+      averageScore: round(sum / count),
+    }),
+  )
+
+  return {
+    totalQuizzesTaken: rows.length,
+    averageScore: round(averageScore),
+    scoreOverTime,
+    breakdownByType,
+  }
+}

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -88,7 +88,7 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
   )
 
   return {
-    totalQuizzesTaken: rows.length,
+    totalQuizzesTaken: gradedCount,
     averageScore: round(averageScore),
     scoreOverTime,
     breakdownByType,

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -56,7 +56,10 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
 
   const byDay = new Map<string, { sum: number; count: number }>()
   for (const r of gradedRows) {
-    const date = r.createdAt.toISOString().slice(0, 10)
+    const y = r.createdAt.getFullYear()
+    const m = String(r.createdAt.getMonth() + 1).padStart(2, '0')
+    const d = String(r.createdAt.getDate()).padStart(2, '0')
+    const date = `${y}-${m}-${d}`
     const entry = byDay.get(date) ?? { sum: 0, count: 0 }
     entry.sum += toPercent(r.correctAnswers, r.totalQuestions)
     entry.count += 1

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -59,10 +59,7 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     gradedScoreSum += percent
     gradedCount += 1
 
-    const y = r.createdAt.getFullYear()
-    const m = String(r.createdAt.getMonth() + 1).padStart(2, '0')
-    const d = String(r.createdAt.getDate()).padStart(2, '0')
-    const date = `${y}-${m}-${d}`
+    const date = r.createdAt.toISOString().slice(0, 10)
     const dayEntry = byDay.get(date) ?? { sum: 0, count: 0 }
     dayEntry.sum += percent
     dayEntry.count += 1


### PR DESCRIPTION
Added `GET /analytics/summary` (auth-guarded) that returns aggregated quiz analytics for the logged-in user.

Response shape
- `totalQuizzesTaken: number`
- `averageScore: number` (0–100, percentage)
- `scoreOverTime: { date: string, score: number }[]` (aggregated by day, sorted ascending)
- `breakdownByType: { type, quizCount, averageScore }[]`

Implementation
- One SQL query joining `quiz_results` + `quizzes`, aggregated in JS (same dataset feeds all 4 metrics — avoids 4 round trips)
- A small fix in `src/config/swagger.ts` — converts `path.join` results to forward slashes so swagger-jsdoc's glob matcher finds route files on Windows. Without this, the OpenAPI spec was missing all route definitions when the server ran on Windows.