### PR TITLE
feat: add per-quiz history to analytics summary

### DIFF
--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -15,11 +15,21 @@ export type TypeBreakdown = {
   averageScore: number
 }
 
+export type QuizHistoryItem = {
+  quizId: string
+  quizTitle: string
+  correctAnswers: number
+  totalQuestions: number
+  score: number
+  date: string
+}
+
 export type AnalyticsSummary = {
   totalQuizzesTaken: number
   averageScore: number
   scoreOverTime: ScorePoint[]
   breakdownByType: TypeBreakdown[]
+  history: QuizHistoryItem[]
   totalTokensUsed: number
 }
 
@@ -30,6 +40,8 @@ const round = (n: number) => Math.round(n * 100) / 100
 export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSummary> => {
   const quizRows = await db
     .select({
+      quizId: quizResults.quizId,
+      quizTitle: quizzes.title,
       createdAt: quizResults.createdAt,
       totalQuestions: quizResults.totalQuestions,
       correctAnswers: quizResults.correctAnswers,
@@ -60,6 +72,7 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
       averageScore: 0,
       scoreOverTime: [],
       breakdownByType: [],
+      history: [],
       totalTokensUsed,
     }
   }
@@ -68,6 +81,7 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
   let gradedCount = 0
   const byDay = new Map<string, { sum: number; count: number }>()
   const byType = new Map<QuestionType, { sum: number; count: number }>()
+  const history: QuizHistoryItem[] = []
 
   for (const r of quizRows) {
     if (r.totalQuestions <= 0) continue
@@ -75,6 +89,15 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     const percent = toPercent(r.correctAnswers, r.totalQuestions)
     gradedScoreSum += percent
     gradedCount += 1
+
+    history.push({
+      quizId: r.quizId,
+      quizTitle: r.quizTitle,
+      correctAnswers: r.correctAnswers,
+      totalQuestions: r.totalQuestions,
+      score: round(percent),
+      date: r.createdAt.toISOString(),
+    })
 
     const date = r.createdAt.toISOString().slice(0, 10)
     const dayEntry = byDay.get(date) ?? { sum: 0, count: 0 }
@@ -104,11 +127,14 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     }),
   )
 
+  history.sort((a, b) => b.date.localeCompare(a.date))
+
   return {
     totalQuizzesTaken: gradedCount,
     averageScore: round(averageScore),
     scoreOverTime,
     breakdownByType,
+    history,
     totalTokensUsed,
   }
 }

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -127,7 +127,7 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     }),
   )
 
-  history.sort((a, b) => b.date.localeCompare(a.date))
+  history.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))
 
   return {
     totalQuizzesTaken: gradedCount,


### PR DESCRIPTION
Closes history-result in frontend

  Adds a `history` array to `GET /analytics/summary` — one entry per solved quiz: `{ quizId,
  quizTitle, correctAnswers, totalQuestions, score, date }`, newest first.

  Used `scoreOverTime` at first but it's day-averaged, so multiple quizzes on the same day collapse
  into one point — no good for a per-quiz list. The summary query already scans quiz_results joined to
  quizzes, so history is built in the same loop with two extra columns: no new query or endpoint. The
  UNIQUE(user_id, quiz_id) constraint keeps it one row per quiz (retakes overwrite).

  Only touches `src/services/analytics.service.ts`. tsc passes; scoreOverTime and breakdownByType 
  unchanged. No pagination yet — fine at current scale, can add a dedicated endpoint later if result 
  counts grow.