### PR TITLE
feat: native PDF via OpenAI SDK file block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "node-cron": "^4.2.1",
         "nodemailer": "^6.9.4",
         "openai": "^6.38.0",
-        "pdf2json": "^4.0.3",
         "pg": "^8.20.0",
         "puppeteer": "^24.10.0",
         "swagger-jsdoc": "^6.2.8",
@@ -8618,18 +8617,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "license": "MIT"
-    },
-    "node_modules/pdf2json": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-4.0.3.tgz",
-      "integrity": "sha512-QErPemxRHDI2RUli3+9/mv4V6Ib9VWI+UoP2S82yXEQtoXzWvu9NSjjo3vyiUiVJv+CJFuzNiKUI+UFFUdv8Lg==",
-      "license": "Apache-2.0",
-      "bin": {
-        "pdf2json": "bin/pdf2json.js"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      }
     },
     "node_modules/pend": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "node-cron": "^4.2.1",
     "nodemailer": "^6.9.4",
     "openai": "^6.38.0",
-    "pdf2json": "^4.0.3",
     "pg": "^8.20.0",
     "puppeteer": "^24.10.0",
     "swagger-jsdoc": "^6.2.8",

--- a/src/helpers/utils/quizLambdaUtils.ts
+++ b/src/helpers/utils/quizLambdaUtils.ts
@@ -7,6 +7,10 @@ import type { QuestionType } from '../../types/questionTypes'
 /** Maximum file size allowed to be read from S3 for quiz generation (25 MB) */
 export const QUIZ_FILE_MAX_BYTES = 25 * 1024 * 1024
 
+export type QuizSource =
+  | { kind: 'text'; text: string }
+  | { kind: 'pdf'; buffer: Buffer; filename: string }
+
 export const streamToBuffer = async (stream: Readable, maxBytes?: number): Promise<Buffer> => {
   const chunks: Buffer[] = []
   let totalBytes = 0
@@ -19,65 +23,6 @@ export const streamToBuffer = async (stream: Readable, maxBytes?: number): Promi
     chunks.push(buffer)
   }
   return Buffer.concat(chunks)
-}
-
-const PDF_PARSE_TIMEOUT_MS = 45_000
-
-const extractPdfText = (buffer: Buffer): Promise<string> => {
-  // pdf2json is CJS and callback-based — pass verbosity=0 to suppress link/form warnings
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const PDFParser = require('pdf2json') as new (
-    context?: null,
-    verbosity?: number,
-  ) => {
-    on(
-      event: 'pdfParser_dataReady',
-      cb: (data: { Pages: Array<{ Texts: Array<{ R: Array<{ T: string }> }> }> }) => void,
-    ): void
-    on(event: 'pdfParser_dataError', cb: (err: { parserError: Error }) => void): void
-    parseBuffer(buf: Buffer): void
-  }
-
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error(`PDF parsing exceeded ${PDF_PARSE_TIMEOUT_MS / 1000}s`)),
-      PDF_PARSE_TIMEOUT_MS,
-    )
-
-    // verbosity=0 suppresses the per-link "Unsupported: field.type of Link" console noise
-    const parser = new PDFParser(null, 0)
-
-    parser.on('pdfParser_dataError', ({ parserError }) => {
-      clearTimeout(timer)
-      reject(parserError)
-    })
-
-    parser.on('pdfParser_dataReady', (data) => {
-      clearTimeout(timer)
-      const safeDecode = (s: string) => {
-        try {
-          return decodeURIComponent(s)
-        } catch {
-          return s
-        }
-      }
-      const text = data.Pages.map((page) => {
-        const blocks = page.Texts.map((t) => t.R.map((r) => safeDecode(r.T)).join(''))
-        return blocks.join('\n')
-      }).join('\n\n')
-
-      const trimmed = text.trim()
-      if (!trimmed) {
-        reject(
-          new Error('PDF appears to be empty or contains only images — no text could be extracted'),
-        )
-      } else {
-        resolve(trimmed)
-      }
-    })
-
-    parser.parseBuffer(buffer)
-  })
 }
 
 const extractDocxText = async (buffer: Buffer): Promise<string> => {
@@ -117,27 +62,24 @@ const extractPptxText = (buffer: Buffer): string => {
   return text
 }
 
-export const extractTextFromBuffer = async (
+export const extractSourceFromBuffer = async (
   buffer: Buffer,
   contentType: string,
   key: string,
-): Promise<string> => {
+): Promise<QuizSource> => {
   const lowerKey = key.toLowerCase()
   const isPdf = contentType === 'application/pdf' || lowerKey.endsWith('.pdf')
   const isDocx = contentType.includes('wordprocessingml') || lowerKey.endsWith('.docx')
   const isPptx = contentType.includes('presentationml') || lowerKey.endsWith('.pptx')
 
-  if (isPdf) return extractPdfText(buffer)
-  if (isDocx) return extractDocxText(buffer)
-  if (isPptx) return extractPptxText(buffer)
+  if (isPdf) {
+    const filename = key.split('/').pop() || 'document.pdf'
+    return { kind: 'pdf', buffer, filename }
+  }
+  if (isDocx) return { kind: 'text', text: await extractDocxText(buffer) }
+  if (isPptx) return { kind: 'text', text: extractPptxText(buffer) }
 
-  return buffer.toString('utf-8')
-}
-
-/** @deprecated Use streamToBuffer + extractTextFromBuffer instead */
-export const streamToString = async (stream: Readable, maxBytes?: number) => {
-  const buffer = await streamToBuffer(stream, maxBytes)
-  return buffer.toString('utf-8')
+  return { kind: 'text', text: buffer.toString('utf-8') }
 }
 
 export const normalizeQuestionType = (value: string | undefined): QuestionType => {

--- a/src/lambda/quizGenerator.ts
+++ b/src/lambda/quizGenerator.ts
@@ -7,11 +7,12 @@ import { getLambdaDb } from './dbClient'
 import { s3Client } from './s3Client'
 import { questionOptions, questions, quizJobs, quizzes } from '../database/schema'
 import {
-  extractTextFromBuffer,
+  extractSourceFromBuffer,
   normalizeQuestionType,
   QUIZ_FILE_MAX_BYTES,
   streamToBuffer,
 } from '../helpers/utils/quizLambdaUtils'
+import type { QuizSource } from '../helpers/utils/quizLambdaUtils'
 import { getByokById } from '../services/byok.service'
 import { generateQuizFromText } from '../services/helpers/quizAi'
 import type { AiQuiz, AiQuizResult } from '../services/helpers/quizAi'
@@ -111,7 +112,7 @@ const persistQuiz = async (
   return quizInsert
 }
 
-const fetchSourceText = async (bucket: string, key: string): Promise<string> => {
+const fetchSource = async (bucket: string, key: string): Promise<QuizSource> => {
   const s3Response = await s3Client.send(new GetObjectCommand({ Bucket: bucket, Key: key }))
 
   if (!s3Response.Body) {
@@ -119,7 +120,7 @@ const fetchSourceText = async (bucket: string, key: string): Promise<string> => 
   }
 
   const buffer = await streamToBuffer(s3Response.Body as Readable, QUIZ_FILE_MAX_BYTES)
-  return extractTextFromBuffer(buffer, s3Response.ContentType ?? '', key)
+  return extractSourceFromBuffer(buffer, s3Response.ContentType ?? '', key)
 }
 
 export const handler = async (event: LambdaEvent) => {
@@ -131,8 +132,7 @@ export const handler = async (event: LambdaEvent) => {
   const db = await getLambdaDb()
 
   try {
-    const sourceTexts = await Promise.all(allKeys.map((k) => fetchSourceText(event.bucket, k)))
-    const sourceText = sourceTexts.join('\n\n---\n\n')
+    const sources = await Promise.all(allKeys.map((k) => fetchSource(event.bucket, k)))
 
     let apiKey
     if (event.apiKeyId) apiKey = await getByokById(event.apiKeyId, event.userId, db)
@@ -140,7 +140,7 @@ export const handler = async (event: LambdaEvent) => {
     const result = event.quiz
       ? { quiz: event.quiz }
       : await generateQuizFromText({
-          sourceText,
+          sources,
           questionCount: event.questionCount,
           type: event.type ? (normalizeQuestionType(event.type) as QuestionType) : undefined,
           userInstructions: event.userInstructions,

--- a/src/services/clients/openrouter.client.ts
+++ b/src/services/clients/openrouter.client.ts
@@ -3,10 +3,7 @@ import OpenAI from 'openai'
 import { logger } from '../../config/logger'
 import { AppError } from '../../helpers/AppError'
 
-export type ChatMessage = {
-  role: 'system' | 'user' | 'assistant'
-  content: string
-}
+export type ChatMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam
 
 export type JsonSchema = {
   name: string

--- a/src/services/helpers/quizAi.ts
+++ b/src/services/helpers/quizAi.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai'
 
 import { DEFAULT_MODEL } from '../../constants/models'
+import type { QuizSource } from '../../helpers/utils/quizLambdaUtils'
 import { buildQuizSystemPrompt } from '../../prompts'
 import type { DifficultyType } from '../../types/difficultyTypes'
 import { QUESTION_TYPES } from '../../types/questionTypes'
@@ -33,7 +34,7 @@ export type AiQuizResult = {
 }
 
 type GenerateOptions = {
-  sourceText: string
+  sources: QuizSource[]
   questionCount?: number
   type?: QuestionType
   userInstructions?: string
@@ -86,7 +87,7 @@ const buildSchema = (type?: QuestionType) => ({
 })
 
 export const generateQuizFromText = async ({
-  sourceText,
+  sources,
   questionCount,
   type,
   userInstructions,
@@ -99,20 +100,45 @@ export const generateQuizFromText = async ({
   const count =
     questionCount && questionCount > 0 ? Math.min(questionCount, 30) : DEFAULT_QUESTION_COUNT
 
-  const truncated = sourceText.slice(0, SOURCE_TEXT_LIMIT)
-  const wasTruncated = sourceText.length > SOURCE_TEXT_LIMIT
+  const textParts = sources.filter(
+    (s): s is Extract<QuizSource, { kind: 'text' }> => s.kind === 'text',
+  )
+  const pdfParts = sources.filter(
+    (s): s is Extract<QuizSource, { kind: 'pdf' }> => s.kind === 'pdf',
+  )
 
-  const userParts = [
-    `Source material${wasTruncated ? ' (truncated)' : ''}:\n"""\n${truncated}\n"""`,
-  ]
+  const joinedText = textParts.map((s) => s.text).join('\n\n---\n\n')
+  const truncated = joinedText.slice(0, SOURCE_TEXT_LIMIT)
+  const wasTruncated = joinedText.length > SOURCE_TEXT_LIMIT
 
+  const content: OpenAI.Chat.Completions.ChatCompletionContentPart[] = []
+
+  for (const pdf of pdfParts) {
+    content.push({
+      type: 'file',
+      file: {
+        filename: pdf.filename,
+        file_data: `data:application/pdf;base64,${pdf.buffer.toString('base64')}`,
+      },
+    })
+  }
+
+  const textParagraphs: string[] = []
+  if (truncated) {
+    textParagraphs.push(
+      `Source material${wasTruncated ? ' (truncated)' : ''}:\n"""\n${truncated}\n"""`,
+    )
+  } else if (pdfParts.length > 0) {
+    textParagraphs.push('Source material is the attached PDF document(s).')
+  }
   if (userInstructions) {
-    userParts.push(`Additional instructions from the user:\n${userInstructions}`)
+    textParagraphs.push(`Additional instructions from the user:\n${userInstructions}`)
+  }
+  if (defaultTitle) {
+    textParagraphs.push(`Suggested title (you may improve it): ${defaultTitle}`)
   }
 
-  if (defaultTitle) {
-    userParts.push(`Suggested title (you may improve it): ${defaultTitle}`)
-  }
+  content.push({ type: 'text', text: textParagraphs.join('\n\n') })
 
   const result = await chatJSON<AiQuiz>({
     apiKey,
@@ -121,7 +147,7 @@ export const generateQuizFromText = async ({
     temperature: 0.3,
     messages: [
       { role: 'system', content: buildQuizSystemPrompt(type, count, userBio, difficulty) },
-      { role: 'user', content: userParts.join('\n\n') },
+      { role: 'user', content },
     ],
   })
 


### PR DESCRIPTION
Closes #69 — drops the manual `pdf2json` parser and hands PDFs to the model as
  native file input through the OpenAI SDK (pointed at OpenRouter), which parses
  them server-side. Removes the custom PDF parsing path from the Lambda.

  ## Changes
  - Remove `extractPdfText` / `pdf2json` usage; `pdf2json` dropped from dependencies.
  - PDFs are sent as an OpenAI SDK `file` content part (base64 data URL); OpenRouter
    extracts the text, so no local PDF parsing.
  - `quizGenerator` Lambda now splits sources: PDFs → native file input, everything
    else → existing extraction.
  - No new credentials: rides on the existing `OPENROUTER_API_KEY` (no separate OpenAI key).