### PR TITLE
Feat/analytics history v2

### DIFF
--- a/drizzle/0016_drop_quiz_results_unique.sql
+++ b/drizzle/0016_drop_quiz_results_unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "quiz_results" DROP CONSTRAINT IF EXISTS "quiz_results_user_quiz_unique";

--- a/src/controllers/analyticsController.ts
+++ b/src/controllers/analyticsController.ts
@@ -1,8 +1,11 @@
 import type { NextFunction, Request, Response } from 'express'
 
 import { successResponse } from '../helpers/apiResponse'
+import { AppError } from '../helpers/AppError'
 import { getAuthUserId } from '../helpers/utils/authUtils'
 import { getAnalyticsSummary } from '../services/analytics.service'
+import { getQuizHistory } from '../services/history.service'
+import { HistoryQuerySchema } from '../validators/history.schema'
 
 export const getAnalyticsSummaryController = async (
   req: Request,
@@ -13,6 +16,20 @@ export const getAnalyticsSummaryController = async (
     const userId = getAuthUserId(req)
     const summary = await getAnalyticsSummary(userId)
     res.status(200).json(successResponse('Analytics summary retrieved', summary))
+  } catch (error) {
+    next(error)
+  }
+}
+
+export const getQuizHistoryController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = getAuthUserId(req)
+    const parsed = HistoryQuerySchema.safeParse(req.query)
+    if (!parsed.success) {
+      throw new AppError(parsed.error.issues[0].message, 400, 'VALIDATION_ERROR')
+    }
+    const history = await getQuizHistory(userId, parsed.data)
+    res.status(200).json(successResponse('Quiz history retrieved', history))
   } catch (error) {
     next(error)
   }

--- a/src/database/run-sql.ts
+++ b/src/database/run-sql.ts
@@ -1,0 +1,35 @@
+import 'dotenv/config'
+import { readFileSync } from 'fs'
+
+import { Pool } from 'pg'
+
+import { getDatabaseRejectUnauthorized } from '../helpers/utils/dbSsl'
+
+const path = process.argv[2]
+if (!path) {
+  console.error('Usage: ts-node src/database/run-sql.ts <path-to-sql-file>')
+  process.exit(1)
+}
+
+const sql = readFileSync(path, 'utf-8')
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl:
+    process.env.DATABASE_SSL === 'true'
+      ? { rejectUnauthorized: getDatabaseRejectUnauthorized() }
+      : false,
+  max: 1,
+})
+
+pool
+  .query(sql)
+  .then(() => {
+    console.log(`Applied ${path}`)
+    return pool.end()
+  })
+  .catch((err) => {
+    console.error('Failed:', err.message)
+    pool.end()
+    process.exit(1)
+  })

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -225,7 +225,6 @@ export const quizResults = pgTable(
   (table) => ({
     userIdIdx: index('quiz_results_user_id_idx').on(table.userId),
     quizIdIdx: index('quiz_results_quiz_id_idx').on(table.quizId),
-    userQuizUnique: unique('quiz_results_user_quiz_unique').on(table.userId, table.quizId),
   }),
 )
 

--- a/src/routes/analytics.routes.ts
+++ b/src/routes/analytics.routes.ts
@@ -1,6 +1,9 @@
 import { Router } from 'express'
 
-import { getAnalyticsSummaryController } from '../controllers/analyticsController'
+import {
+  getAnalyticsSummaryController,
+  getQuizHistoryController,
+} from '../controllers/analyticsController'
 import { authMiddleware } from '../middlewares/authMiddleware'
 
 const router = Router()
@@ -25,5 +28,47 @@ const router = Router()
  *         description: Not authenticated
  */
 router.get('/analytics/summary', authMiddleware, getAnalyticsSummaryController)
+
+/**
+ * @openapi
+ * /quiz-results/history:
+ *   get:
+ *     tags:
+ *       - Analytics
+ *     security:
+ *       - cookieAuth: []
+ *     summary: Filterable list of the authenticated user's quiz attempts
+ *     parameters:
+ *       - in: query
+ *         name: folderId
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: Restrict to quizzes inside this folder. Omit for all folders.
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           enum: [5, 10, 50]
+ *           default: 10
+ *       - in: query
+ *         name: sort
+ *         schema:
+ *           type: string
+ *           enum: [recent, best, worst]
+ *           default: recent
+ *     responses:
+ *       200:
+ *         description: Quiz history retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiSuccessResponse'
+ *       400:
+ *         description: Invalid query parameters
+ *       401:
+ *         description: Not authenticated
+ */
+router.get('/quiz-results/history', authMiddleware, getQuizHistoryController)
 
 export default router

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -289,7 +289,7 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     {
       folderId: null,
       folderName: 'All quizzes',
-      averageScore: round(allFolder.sum / allFolder.count),
+      averageScore: allFolder.count > 0 ? round(allFolder.sum / allFolder.count) : 0,
       bestScore: round(allFolder.best),
       attemptCount: allFolder.count,
     },
@@ -297,7 +297,7 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
       .map(([key, acc]) => ({
         folderId: key === '' ? null : key,
         folderName: acc.folderName,
-        averageScore: round(acc.sum / acc.count),
+        averageScore: acc.count > 0 ? round(acc.sum / acc.count) : 0,
         bestScore: round(acc.best),
         attemptCount: acc.count,
       }))
@@ -309,7 +309,7 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
       quizId,
       quizTitle: acc.quizTitle,
       folderId: acc.folderId,
-      averageScore: round(acc.sum / acc.count),
+      averageScore: acc.count > 0 ? round(acc.sum / acc.count) : 0,
       bestScore: round(acc.best),
       attemptCount: acc.count,
     }))

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -2,18 +2,20 @@ import { and, eq } from 'drizzle-orm'
 
 import { DEFAULT_MODEL } from '../constants/models'
 import { db } from '../database/database'
-import { quizJobs, quizResults, quizzes } from '../database/schema'
+import { folders, quizJobs, quizResults, quizzes } from '../database/schema'
+import { QUESTION_TYPES } from '../types/questionTypes'
 import type { QuestionType } from '../types/questionTypes'
 
 export type ScorePoint = {
   date: string
   score: number
+  quizId: string
+  quizTitle: string
 }
 
 export type TypeBreakdown = {
   type: QuestionType
   quizCount: number
-  averageScore: number
 }
 
 export type QuizHistoryItem = {
@@ -23,6 +25,24 @@ export type QuizHistoryItem = {
   totalQuestions: number
   score: number
   date: string
+}
+
+/** Folder rollup. The synthetic 'all' entry sits first and covers every quiz. */
+export type FolderStat = {
+  folderId: string | null
+  folderName: string
+  averageScore: number
+  bestScore: number
+  attemptCount: number
+}
+
+export type QuizStat = {
+  quizId: string
+  quizTitle: string
+  folderId: string | null
+  averageScore: number
+  bestScore: number
+  attemptCount: number
 }
 
 export type KeyUsageSummary = {
@@ -44,7 +64,9 @@ export type AnalyticsSummary = {
   totalQuizzesTaken: number
   averageScore: number
   scoreOverTime: ScorePoint[]
-  breakdownByType: TypeBreakdown[]
+  typeBreakdown: TypeBreakdown[]
+  folderStats: FolderStat[]
+  quizStats: QuizStat[]
   history: QuizHistoryItem[]
   totalTokensUsed: number
   keyUsageBreakdown: KeyUsageSummary[]
@@ -64,9 +86,12 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
       totalQuestions: quizResults.totalQuestions,
       correctAnswers: quizResults.correctAnswers,
       quizType: quizzes.type,
+      folderId: quizzes.folderId,
+      folderName: folders.name,
     })
     .from(quizResults)
     .innerJoin(quizzes, eq(quizResults.quizId, quizzes.id))
+    .leftJoin(folders, eq(quizzes.folderId, folders.id))
     .where(eq(quizResults.userId, userId))
 
   const tokenUsageRows = await db
@@ -150,12 +175,25 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     }))
     .sort((a, b) => b.tokensUsed - a.tokensUsed)
 
+  // Always send all 4 type slices so the pie chart can zero-fill empties.
+  const emptyTypeBreakdown: TypeBreakdown[] = QUESTION_TYPES.map((type) => ({ type, quizCount: 0 }))
+
   if (quizRows.length === 0) {
     return {
       totalQuizzesTaken: 0,
       averageScore: 0,
       scoreOverTime: [],
-      breakdownByType: [],
+      typeBreakdown: emptyTypeBreakdown,
+      folderStats: [
+        {
+          folderId: null,
+          folderName: 'All quizzes',
+          averageScore: 0,
+          bestScore: 0,
+          attemptCount: 0,
+        },
+      ],
+      quizStats: [],
       history: [],
       totalTokensUsed,
       keyUsageBreakdown,
@@ -165,9 +203,23 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
 
   let gradedScoreSum = 0
   let gradedCount = 0
-  const byDay = new Map<string, { sum: number; count: number }>()
-  const byType = new Map<QuestionType, { sum: number; count: number }>()
   const history: QuizHistoryItem[] = []
+  const scoreOverTime: ScorePoint[] = []
+
+  type FolderAcc = { folderName: string; sum: number; best: number; count: number }
+  type QuizAcc = {
+    quizTitle: string
+    folderId: string | null
+    sum: number
+    best: number
+    count: number
+  }
+  // Synthetic "all" bucket stays first in the folderStats output.
+  const allFolder: FolderAcc = { folderName: 'All quizzes', sum: 0, best: 0, count: 0 }
+  // folderId may be null (root). Key the map by '' for null so it slots in cleanly.
+  const folderAccs = new Map<string, FolderAcc>()
+  const quizAccs = new Map<string, QuizAcc>()
+  const seenQuizTypes = new Map<string, QuestionType>()
 
   for (const r of quizRows) {
     if (r.totalQuestions <= 0) continue
@@ -185,33 +237,83 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
       date: r.createdAt.toISOString(),
     })
 
-    const date = r.createdAt.toISOString().slice(0, 10)
-    const dayEntry = byDay.get(date) ?? { sum: 0, count: 0 }
-    dayEntry.sum += percent
-    dayEntry.count += 1
-    byDay.set(date, dayEntry)
+    scoreOverTime.push({
+      date: r.createdAt.toISOString(),
+      score: round(percent),
+      quizId: r.quizId,
+      quizTitle: r.quizTitle,
+    })
 
-    if (r.quizType) {
-      const typeEntry = byType.get(r.quizType) ?? { sum: 0, count: 0 }
-      typeEntry.sum += percent
-      typeEntry.count += 1
-      byType.set(r.quizType, typeEntry)
+    allFolder.sum += percent
+    allFolder.count += 1
+    if (percent > allFolder.best) allFolder.best = percent
+
+    const folderKey = r.folderId ?? ''
+    const folderName = r.folderId ? (r.folderName ?? 'Unnamed folder') : 'Root'
+    const folderAcc = folderAccs.get(folderKey) ?? { folderName, sum: 0, best: 0, count: 0 }
+    folderAcc.sum += percent
+    folderAcc.count += 1
+    if (percent > folderAcc.best) folderAcc.best = percent
+    folderAccs.set(folderKey, folderAcc)
+
+    const quizAcc = quizAccs.get(r.quizId) ?? {
+      quizTitle: r.quizTitle,
+      folderId: r.folderId ?? null,
+      sum: 0,
+      best: 0,
+      count: 0,
     }
+    quizAcc.sum += percent
+    quizAcc.count += 1
+    if (percent > quizAcc.best) quizAcc.best = percent
+    quizAccs.set(r.quizId, quizAcc)
+
+    if (r.quizType) seenQuizTypes.set(r.quizId, r.quizType)
   }
 
   const averageScore = gradedCount > 0 ? gradedScoreSum / gradedCount : 0
 
-  const scoreOverTime: ScorePoint[] = Array.from(byDay.entries())
-    .map(([date, { sum, count }]) => ({ date, score: round(sum / count) }))
-    .sort((a, b) => a.date.localeCompare(b.date))
+  scoreOverTime.sort((a, b) => a.date.localeCompare(b.date))
 
-  const breakdownByType: TypeBreakdown[] = Array.from(byType.entries()).map(
-    ([type, { sum, count }]) => ({
-      type,
-      quizCount: count,
-      averageScore: round(sum / count),
-    }),
-  )
+  // Count distinct quizzes per type so the pie reflects library composition.
+  const typeCounts = new Map<QuestionType, number>()
+  for (const type of seenQuizTypes.values()) {
+    typeCounts.set(type, (typeCounts.get(type) ?? 0) + 1)
+  }
+  const typeBreakdown: TypeBreakdown[] = QUESTION_TYPES.map((type) => ({
+    type,
+    quizCount: typeCounts.get(type) ?? 0,
+  }))
+
+  const folderStats: FolderStat[] = [
+    {
+      folderId: null,
+      folderName: 'All quizzes',
+      averageScore: round(allFolder.sum / allFolder.count),
+      bestScore: round(allFolder.best),
+      attemptCount: allFolder.count,
+    },
+    ...Array.from(folderAccs.entries())
+      .map(([key, acc]) => ({
+        folderId: key === '' ? null : key,
+        folderName: acc.folderName,
+        averageScore: round(acc.sum / acc.count),
+        bestScore: round(acc.best),
+        attemptCount: acc.count,
+      }))
+      .sort((a, b) => b.attemptCount - a.attemptCount),
+  ]
+
+  const quizStats: QuizStat[] = Array.from(quizAccs.entries())
+    .map(([quizId, acc]) => ({
+      quizId,
+      quizTitle: acc.quizTitle,
+      folderId: acc.folderId,
+      averageScore: round(acc.sum / acc.count),
+      bestScore: round(acc.best),
+      attemptCount: acc.count,
+    }))
+    .sort((a, b) => b.attemptCount - a.attemptCount)
 
   history.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))
 
@@ -219,7 +321,9 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     totalQuizzesTaken: gradedCount,
     averageScore: round(averageScore),
     scoreOverTime,
-    breakdownByType,
+    typeBreakdown,
+    folderStats,
+    quizStats,
     history,
     totalTokensUsed,
     keyUsageBreakdown,

--- a/src/services/history.service.ts
+++ b/src/services/history.service.ts
@@ -1,0 +1,71 @@
+import { and, asc, desc, eq, sql } from 'drizzle-orm'
+
+import { db } from '../database/database'
+import { folders, quizResults, quizzes } from '../database/schema'
+import type { HistoryQuery } from '../validators/history.schema'
+
+export type HistoryItem = {
+  resultId: string
+  quizId: string
+  quizTitle: string
+  folderId: string | null
+  folderName: string | null
+  score: number
+  correctAnswers: number
+  totalQuestions: number
+  completedAt: string
+}
+
+export type HistoryResponse = {
+  items: HistoryItem[]
+}
+
+const scoreExpr = sql<number>`(${quizResults.correctAnswers}::float / NULLIF(${quizResults.totalQuestions}, 0)) * 100`
+
+export const getQuizHistory = async (
+  userId: string,
+  { folderId, limit, sort }: HistoryQuery,
+): Promise<HistoryResponse> => {
+  const orderBy =
+    sort === 'best'
+      ? [desc(scoreExpr), desc(quizResults.createdAt)]
+      : sort === 'worst'
+        ? [asc(scoreExpr), desc(quizResults.createdAt)]
+        : [desc(quizResults.createdAt)]
+
+  const rows = await db
+    .select({
+      resultId: quizResults.id,
+      quizId: quizResults.quizId,
+      quizTitle: quizzes.title,
+      folderId: quizzes.folderId,
+      folderName: folders.name,
+      correctAnswers: quizResults.correctAnswers,
+      totalQuestions: quizResults.totalQuestions,
+      completedAt: quizResults.createdAt,
+    })
+    .from(quizResults)
+    .innerJoin(quizzes, eq(quizResults.quizId, quizzes.id))
+    .leftJoin(folders, eq(quizzes.folderId, folders.id))
+    .where(
+      and(eq(quizResults.userId, userId), folderId ? eq(quizzes.folderId, folderId) : undefined),
+    )
+    .orderBy(...orderBy)
+    .limit(limit)
+
+  const items: HistoryItem[] = rows
+    .filter((r) => r.totalQuestions > 0)
+    .map((r) => ({
+      resultId: r.resultId,
+      quizId: r.quizId,
+      quizTitle: r.quizTitle,
+      folderId: r.folderId,
+      folderName: r.folderName,
+      score: Math.round((r.correctAnswers / r.totalQuestions) * 100 * 100) / 100,
+      correctAnswers: r.correctAnswers,
+      totalQuestions: r.totalQuestions,
+      completedAt: r.completedAt.toISOString(),
+    }))
+
+  return { items }
+}

--- a/src/services/history.service.ts
+++ b/src/services/history.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gt, sql } from 'drizzle-orm'
 
 import { db } from '../database/database'
 import { folders, quizResults, quizzes } from '../database/schema'
@@ -48,24 +48,26 @@ export const getQuizHistory = async (
     .innerJoin(quizzes, eq(quizResults.quizId, quizzes.id))
     .leftJoin(folders, eq(quizzes.folderId, folders.id))
     .where(
-      and(eq(quizResults.userId, userId), folderId ? eq(quizzes.folderId, folderId) : undefined),
+      and(
+        eq(quizResults.userId, userId),
+        gt(quizResults.totalQuestions, 0),
+        folderId ? eq(quizzes.folderId, folderId) : undefined,
+      ),
     )
     .orderBy(...orderBy)
     .limit(limit)
 
-  const items: HistoryItem[] = rows
-    .filter((r) => r.totalQuestions > 0)
-    .map((r) => ({
-      resultId: r.resultId,
-      quizId: r.quizId,
-      quizTitle: r.quizTitle,
-      folderId: r.folderId,
-      folderName: r.folderName,
-      score: Math.round((r.correctAnswers / r.totalQuestions) * 100 * 100) / 100,
-      correctAnswers: r.correctAnswers,
-      totalQuestions: r.totalQuestions,
-      completedAt: r.completedAt.toISOString(),
-    }))
+  const items: HistoryItem[] = rows.map((r) => ({
+    resultId: r.resultId,
+    quizId: r.quizId,
+    quizTitle: r.quizTitle,
+    folderId: r.folderId,
+    folderName: r.folderName,
+    score: Math.round((r.correctAnswers / r.totalQuestions) * 100 * 100) / 100,
+    correctAnswers: r.correctAnswers,
+    totalQuestions: r.totalQuestions,
+    completedAt: r.completedAt.toISOString(),
+  }))
 
   return { items }
 }

--- a/src/services/open-ended-grading.service.ts
+++ b/src/services/open-ended-grading.service.ts
@@ -46,10 +46,12 @@ const GRADE_SCHEMA = {
 /**
  * Recomputes the score from the persisted per-answer verdicts. correctAnswers =
  * every userAnswer for the quiz with isCorrect=true (auto-gradable + open-ended);
- * totalQuestions is left as set at submit. Idempotent — safe to re-run.
+ * totalQuestions is left as set at submit. Updates only the given attempt's
+ * result row by id. Idempotent — safe to re-run.
  */
 const finalizeScore = async (
   tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+  resultId: string,
   quizId: string,
   userId: string,
 ) => {
@@ -68,7 +70,7 @@ const finalizeScore = async (
   const [current] = await tx
     .select({ totalQuestions: quizResults.totalQuestions })
     .from(quizResults)
-    .where(and(eq(quizResults.quizId, quizId), eq(quizResults.userId, userId)))
+    .where(eq(quizResults.id, resultId))
 
   if (!current) return
 
@@ -79,17 +81,14 @@ const finalizeScore = async (
       wrongAnswers: current.totalQuestions - correctAnswers,
       gradingStatus: 'complete',
     })
-    .where(and(eq(quizResults.quizId, quizId), eq(quizResults.userId, userId)))
+    .where(eq(quizResults.id, resultId))
 }
 
-export const gradeOpenEndedAnswers = async (quizId: string, userId: string): Promise<void> => {
-  // Count auto-gradable questions so we can shrink the denominator on failure.
-  const allQuestions = await db
-    .select({ id: questions.id, type: questions.type })
-    .from(questions)
-    .where(eq(questions.quizId, quizId))
-  const autoGradableCount = allQuestions.filter((q) => q.type !== 'open_ended').length
-
+export const gradeOpenEndedAnswers = async (
+  resultId: string,
+  quizId: string,
+  userId: string,
+): Promise<void> => {
   // Load each answered open-ended question with its model answer + rubric.
   const rows: GradeRow[] = await db
     .select({
@@ -117,7 +116,7 @@ export const gradeOpenEndedAnswers = async (quizId: string, userId: string): Pro
     await db
       .update(quizResults)
       .set({ gradingStatus: 'complete' })
-      .where(and(eq(quizResults.quizId, quizId), eq(quizResults.userId, userId)))
+      .where(eq(quizResults.id, resultId))
     return
   }
 
@@ -161,29 +160,33 @@ export const gradeOpenEndedAnswers = async (quizId: string, userId: string): Pro
           )
       }
 
-      await finalizeScore(tx, quizId, userId)
+      await finalizeScore(tx, resultId, quizId, userId)
     })
   } catch (err) {
     logger.error('Open-ended grading failed', {
+      resultId,
       error: err instanceof Error ? err.message : String(err),
     })
-    // Degrade gracefully: drop open-ended from the denominator and leave their
-    // verdicts null (the UI shows them as ungraded). correctAnswers keeps the
-    // auto-gradable count already persisted at submit.
+    // Degrade gracefully: keep totalQuestions intact so the attempt still shows
+    // up in history/analytics. Open-ended verdicts stay null (UI shows them as
+    // ungraded). correctAnswers stays at the auto-gradable count from submit,
+    // so the percentage reflects what we could actually score.
     const [current] = await db
-      .select({ correctAnswers: quizResults.correctAnswers })
+      .select({
+        totalQuestions: quizResults.totalQuestions,
+        correctAnswers: quizResults.correctAnswers,
+      })
       .from(quizResults)
-      .where(and(eq(quizResults.quizId, quizId), eq(quizResults.userId, userId)))
+      .where(eq(quizResults.id, resultId))
 
     if (current) {
       await db
         .update(quizResults)
         .set({
-          totalQuestions: autoGradableCount,
-          wrongAnswers: autoGradableCount - current.correctAnswers,
+          wrongAnswers: current.totalQuestions - current.correctAnswers,
           gradingStatus: 'failed',
         })
-        .where(and(eq(quizResults.quizId, quizId), eq(quizResults.userId, userId)))
+        .where(eq(quizResults.id, resultId))
     }
   }
 }

--- a/src/services/quiz-submission.service.ts
+++ b/src/services/quiz-submission.service.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from 'drizzle-orm'
+import { and, desc, eq, inArray, sql } from 'drizzle-orm'
 
 import { gradeOpenEndedAnswers } from './open-ended-grading.service'
 import { logger } from '../config/logger'
@@ -145,8 +145,8 @@ export const submitQuiz = async (
     return null
   }
 
-  // Keep only the first answer per question. A client could send duplicates,
-  // and (userId, questionId) is unique — duplicates would break the insert below.
+  // Keep only the first answer per question. A client could send duplicates
+  // (e.g. a retry from two tabs), and we want one row per question per attempt.
   const seenQuestionIds = new Set<string>()
   const answers = rawAnswers.filter((answer) => {
     if (seenQuestionIds.has(answer.questionId)) return false
@@ -229,8 +229,8 @@ export const submitQuiz = async (
   const answersByQuestion = new Map(answers.map((a) => [a.questionId, a]))
 
   const result = await db.transaction(async (tx) => {
-    // Record a result for every question in the quiz, ensuring that unanswered
-    // questions are explicitly marked as incorrect.
+    // user_answers stays one row per (user, question) — answer detail tracks
+    // the latest attempt, while score per attempt is preserved in quiz_results.
     const answerValues = quizQuestions.map((q) => {
       const answer = answersByQuestion.get(q.id)
       return {
@@ -244,12 +244,6 @@ export const submitQuiz = async (
       }
     })
 
-    // This submission is the authoritative attempt. We upsert a row for every
-    // question in the quiz (answered or not), so questions left unanswered now
-    // overwrite any stale answer/verdict from an earlier submission. Upserting
-    // (rather than delete-then-insert) keeps a concurrent double-submit — e.g.
-    // two tabs, or a retry — from racing on the (userId, questionId) unique
-    // constraint and 500ing.
     if (answerValues.length > 0) {
       await tx
         .insert(userAnswers)
@@ -266,6 +260,7 @@ export const submitQuiz = async (
         })
     }
 
+    // Append a new attempt rather than upserting — drives History + multi-attempt analytics.
     const [resultRow] = await tx
       .insert(quizResults)
       .values({
@@ -275,10 +270,6 @@ export const submitQuiz = async (
         correctAnswers,
         wrongAnswers,
         gradingStatus,
-      })
-      .onConflictDoUpdate({
-        target: [quizResults.userId, quizResults.quizId],
-        set: { totalQuestions, correctAnswers, wrongAnswers, gradingStatus },
       })
       .returning()
 
@@ -296,12 +287,12 @@ export const submitQuiz = async (
   // status to 'complete'/'failed' (bounded by a 30s LLM timeout), so this
   // never throws; we just re-read the row it updated in place.
   if (gradingStatus === 'pending') {
-    await gradeOpenEndedAnswers(quizId, userId)
+    await gradeOpenEndedAnswers(result.id, quizId, userId)
 
     const [finalized] = await db
       .select()
       .from(quizResults)
-      .where(and(eq(quizResults.quizId, quizId), eq(quizResults.userId, userId)))
+      .where(eq(quizResults.id, result.id))
       .limit(1)
 
     if (finalized) return finalized
@@ -324,6 +315,7 @@ export const getQuizResult = async (quizId: string, userId: string) => {
     })
     .from(quizResults)
     .where(and(eq(quizResults.quizId, quizId), eq(quizResults.userId, userId)))
+    .orderBy(desc(quizResults.createdAt))
     .limit(1)
 
   if (!result) {
@@ -331,8 +323,8 @@ export const getQuizResult = async (quizId: string, userId: string) => {
     return null
   }
 
-  // One pass over the user's stored answers yields both the per-answer verdicts
-  // (graded open-ended) and the raw answers used to rebuild the review on refresh.
+  // user_answers is one row per (user, question) — these are always the latest
+  // submission's answers regardless of how many attempts exist in quiz_results.
   const answerRows = await db
     .select({
       questionId: userAnswers.questionId,

--- a/src/validators/history.schema.ts
+++ b/src/validators/history.schema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+export const HistoryQuerySchema = z.object({
+  /** Folder UUID, or omitted to return history across all folders. */
+  folderId: z.string().uuid().optional(),
+  /** How many attempts to return. */
+  limit: z.coerce
+    .number()
+    .int()
+    .refine((n) => n === 5 || n === 10 || n === 50, {
+      message: 'limit must be 5, 10, or 50',
+    })
+    .default(10),
+  /** Ordering: most recent first, highest score first, or lowest score first. */
+  sort: z.enum(['recent', 'best', 'worst']).default('recent'),
+})
+
+export type HistoryQuery = z.infer<typeof HistoryQuerySchema>


### PR DESCRIPTION
Closes #95

## Summary
Quiz attempts now persist as separate `quiz_results` rows instead of overwriting on retake. Analytics gets per-folder and per-quiz rollups, a 4-entry type breakdown (zero-filled for the pie chart), and one `scoreOverTime` point per attempt. A new filterable history endpoint replaces the embedded history list.

## Commits
- `feat(db): allow multiple quiz attempts` — drop `quiz_results_user_quiz_unique`, change submit upsert → plain insert, scope grading by `resultId`, and preserve `totalQuestions` on grading failure so failed attempts still appear in analytics.
- `feat(analytics): per-folder + per-quiz stats and pie typeBreakdown` — new response fields `folderStats[]`, `quizStats[]`, `typeBreakdown[]` (always 4 entries). `scoreOverTime` is now one point per attempt with `quizId` + `quizTitle`.
- `feat(history): filterable quiz history endpoint` — new `GET /quiz-results/history?folderId=&limit=5|10|50&sort=recent|best|worst` route.
- `chore(db): add run-sql helper for applying migrations` — `src/database/run-sql.ts` lets anyone apply a single .sql file via the project's existing ts-node toolchain.


## Database migration

Adds `drizzle/0016_drop_quiz_results_unique.sql`:

```sql
ALTER TABLE "quiz_results" DROP CONSTRAINT IF EXISTS "quiz_results_user_quiz_unique";
```

**Apply before running this branch (pick one):**

- **Project helper (no extra install required)** — added in this PR:
  ```bash
  npx ts-node src/database/run-sql.ts drizzle/0016_drop_quiz_results_unique.sql
  ```
- **psql** if you have it installed:
  ```bash
  psql $DATABASE_URL -f drizzle/0016_drop_quiz_results_unique.sql
  ```
- **A GUI Postgres client** (pgAdmin / DBeaver / TablePlus) — open the file and run it.

No data is modified — only a constraint is dropped. Existing rows are preserved.

### ⚠️ Heads up
- Anyone checking out this branch **must** apply the migration first, or submit will 500.
- Once merged to `dev`, run the migration in the dev DB as part of the deploy.
- After merge, teammates pulling `dev` need to apply it locally too.

## New endpoint
```
GET /quiz-results/history
  ?folderId=<uuid>     (optional — restrict to a folder)
  ?limit=5|10|50       (default 10)
  ?sort=recent|best|worst   (default recent)
```
Returns `{ items: HistoryItem[] }` where each item has `resultId`, `quizId`, `quizTitle`, `folderId`, `folderName`, `score (0-100)`, `correctAnswers`, `totalQuestions`, `completedAt`.

## Updated `/analytics/summary` shape
Added fields:
- `folderStats: FolderStat[]` — synthetic "All quizzes" first, then one entry per folder with `averageScore`, `bestScore`, `attemptCount`.
- `quizStats: QuizStat[]` — per-quiz rollup.
- `typeBreakdown: TypeBreakdown[]` — always 4 entries (zero-filled) for the pie. The `averageScore` field on type breakdown is removed.

`scoreOverTime` is now per-attempt (full ISO timestamp) and includes `quizId` + `quizTitle`. `history`, `totalQuizzesTaken`, and `averageScore` are kept for backward compat with the current frontend; the frontend PR will switch over and these can be removed in a follow-up.

## Known trade-off
`user_answers` is unchanged — still one row per `(user, question)`. This means score per attempt is preserved in `quiz_results`, but the per-question answer review on the result page always reflects the **latest** submission. If users complain, follow-up work would add `result_id` to `user_answers`. Deliberately kept out of this PR to limit scope.

## Test plan
- [x] Migration applied cleanly on local dev DB
- [x] Submit a quiz twice with different answers → two rows in `quiz_results`
- [x] `/analytics/summary` returns `folderStats`, `quizStats`, and 4-entry `typeBreakdown`
- [x] `scoreOverTime` shows distinct points per attempt
- [x] `GET /quiz-results/history` default returns 10 most recent
- [x] `sort=best` returns highest score first; `sort=worst` lowest first
- [x] `limit=5` returns 5 items; `limit=42` returns 400
- [x] Failed open-ended grading no longer hides the attempt — appears with `score=0` and `gradingStatus=failed`
- [x] `folderId=<uuid>` filter (no folders created locally — verifying with frontend PR)
- [x] Open-ended grading completes when `OPENROUTER_API_KEY` is set
