### PR TITLE
test: complete issue #46 backend unit + integration coverage

### DIFF
--- a/tests/integration/quiz.test.ts
+++ b/tests/integration/quiz.test.ts
@@ -2,12 +2,18 @@ import request from 'supertest'
 import { describe, it, vi, beforeEach, expect } from 'vitest'
 
 import app from '../../src/app'
+import * as quizSubmissionService from '../../src/services/quiz-submission.service'
 import * as quizService from '../../src/services/quiz.service'
 
 vi.mock('../../src/services/quiz.service')
+vi.mock('../../src/services/quiz-submission.service')
 
 vi.mock('../../src/middlewares/authMiddleware', () => ({
-  authMiddleware: vi.fn((req, res, next) => {
+  authMiddleware: vi.fn((req, _res, next) => {
+    ;(req as Record<string, unknown>).user = { id: 'user-1' }
+    next()
+  }),
+  optionalAuthMiddleware: vi.fn((req, _res, next) => {
     ;(req as Record<string, unknown>).user = { id: 'user-1' }
     next()
   }),
@@ -54,6 +60,35 @@ describe('Quiz Integration Tests', () => {
     })
   })
 
+  describe('PATCH /quizzes/:id', () => {
+    it('should return 200 and the updated quiz', async () => {
+      const updated = { id: 'quiz-1', title: 'Renamed Quiz' }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vi.mocked(quizService.updateQuizById).mockResolvedValue(updated as any)
+
+      const response = await request(app).patch('/quizzes/quiz-1').send({ title: 'Renamed Quiz' })
+
+      expect(response.status).toBe(200)
+      expect(response.body.message).toBe('Quiz updated successfully')
+      expect(response.body.data.title).toBe('Renamed Quiz')
+    })
+
+    it('should return 404 when the quiz does not exist', async () => {
+      vi.mocked(quizService.updateQuizById).mockResolvedValue(null)
+
+      const response = await request(app).patch('/quizzes/missing').send({ title: 'Whatever' })
+
+      expect(response.status).toBe(404)
+    })
+
+    it('should return 400 when no updatable field is provided', async () => {
+      const response = await request(app).patch('/quizzes/quiz-1').send({})
+
+      expect(response.status).toBe(400)
+      expect(quizService.updateQuizById).not.toHaveBeenCalled()
+    })
+  })
+
   describe('DELETE /quizzes/:id', () => {
     it('should return 200 when quiz is deleted', async () => {
       vi.mocked(quizService.deleteQuizById).mockResolvedValue(true)
@@ -62,6 +97,68 @@ describe('Quiz Integration Tests', () => {
 
       expect(response.status).toBe(200)
       expect(response.body.message).toBe('Quiz deleted successfully')
+    })
+  })
+
+  describe('POST /quizzes/:id/submit', () => {
+    const questionId = '11111111-1111-4111-8111-111111111111'
+    const optionId = '22222222-2222-4222-8222-222222222222'
+
+    it('should return 200 and the scored result for a valid submission', async () => {
+      const scored = {
+        id: 'result-1',
+        totalQuestions: 2,
+        correctAnswers: 2,
+        wrongAnswers: 0,
+        gradingStatus: 'complete',
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vi.mocked(quizSubmissionService.submitQuiz).mockResolvedValue(scored as any)
+
+      const response = await request(app)
+        .post('/quizzes/quiz-1/submit')
+        .send({ answers: [{ questionId, selectedOptionId: optionId }] })
+
+      expect(response.status).toBe(200)
+      expect(response.body.message).toBe('Quiz submitted successfully')
+      expect(response.body.data.correctAnswers).toBe(2)
+      expect(response.body.data.totalQuestions).toBe(2)
+      expect(quizSubmissionService.submitQuiz).toHaveBeenCalledWith('quiz-1', 'user-1', [
+        { questionId, selectedOptionId: optionId },
+      ])
+    })
+
+    it('should return 404 when the quiz is not found', async () => {
+      vi.mocked(quizSubmissionService.submitQuiz).mockResolvedValue(null)
+
+      const response = await request(app)
+        .post('/quizzes/quiz-1/submit')
+        .send({ answers: [{ questionId, selectedOptionId: optionId }] })
+
+      expect(response.status).toBe(404)
+    })
+
+    it('should return 400 and not score when answers contain a duplicate questionId', async () => {
+      const response = await request(app)
+        .post('/quizzes/quiz-1/submit')
+        .send({
+          answers: [
+            { questionId, selectedOptionId: optionId },
+            { questionId, selectedOptionId: optionId },
+          ],
+        })
+
+      expect(response.status).toBe(400)
+      expect(quizSubmissionService.submitQuiz).not.toHaveBeenCalled()
+    })
+
+    it('should return 400 when an answer carries no selection', async () => {
+      const response = await request(app)
+        .post('/quizzes/quiz-1/submit')
+        .send({ answers: [{ questionId }] })
+
+      expect(response.status).toBe(400)
+      expect(quizSubmissionService.submitQuiz).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -8,6 +8,7 @@ const { dbMock } = vi.hoisted(() => {
     select: vi.fn().mockReturnThis(),
     from: vi.fn().mockReturnThis(),
     innerJoin: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnThis(),
     then: vi.fn((resolve) => resolve([])),
   }
@@ -24,6 +25,7 @@ describe('AnalyticsService', () => {
     dbMock.select.mockReturnThis()
     dbMock.from.mockReturnThis()
     dbMock.innerJoin.mockReturnThis()
+    dbMock.leftJoin.mockReturnThis()
     dbMock.where.mockReturnThis()
   })
 

--- a/tests/unit/apiKeyCrypto.test.ts
+++ b/tests/unit/apiKeyCrypto.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, beforeEach, afterEach, expect } from 'vitest'
+
+import {
+  decryptApiKeyValue,
+  encryptApiKeyValue,
+  maskApiKeyValue,
+} from '../../src/helpers/apiKeyCrypto'
+
+describe('apiKeyCrypto', () => {
+  beforeEach(() => {
+    process.env.API_KEY_ENCRYPTION_SECRET = 'test-encryption-secret'
+  })
+
+  afterEach(() => {
+    process.env.API_KEY_ENCRYPTION_SECRET = 'test-encryption-secret'
+  })
+
+  describe('encrypt / decrypt round-trip', () => {
+    it('should decrypt back to the original plaintext', () => {
+      const plain = 'sk-test-1234567890-abcdef'
+
+      const cipherText = encryptApiKeyValue(plain)
+      expect(decryptApiKeyValue(cipherText)).toBe(plain)
+    })
+
+    it('should produce iv:authTag:data shaped ciphertext', () => {
+      const cipherText = encryptApiKeyValue('secret-value')
+
+      expect(cipherText.split(':')).toHaveLength(3)
+    })
+
+    it('should produce a different ciphertext each call but decrypt to the same value', () => {
+      const plain = 'sk-deterministic-input'
+
+      const first = encryptApiKeyValue(plain)
+      const second = encryptApiKeyValue(plain)
+
+      // Random IV per call → ciphertext differs even for identical input.
+      expect(first).not.toBe(second)
+      expect(decryptApiKeyValue(first)).toBe(plain)
+      expect(decryptApiKeyValue(second)).toBe(plain)
+    })
+
+    it('should round-trip unicode values', () => {
+      expect(decryptApiKeyValue(encryptApiKeyValue('🔑 ключ key'))).toBe('🔑 ключ key')
+    })
+
+    it('should throw when the ciphertext format is invalid', () => {
+      expect(() => decryptApiKeyValue('not-a-valid-cipher')).toThrow(
+        'Invalid encrypted API key format',
+      )
+    })
+
+    it('should throw when the encryption secret is missing', () => {
+      delete process.env.API_KEY_ENCRYPTION_SECRET
+      expect(() => encryptApiKeyValue('value')).toThrow('API_KEY_ENCRYPTION_SECRET is not defined')
+    })
+  })
+
+  describe('maskApiKeyValue', () => {
+    it('should fully mask short values', () => {
+      expect(maskApiKeyValue('short')).toBe('********')
+      expect(maskApiKeyValue('12345678')).toBe('********')
+    })
+
+    it('should keep the first and last four characters for long values', () => {
+      expect(maskApiKeyValue('sk-abcdef123456')).toBe('sk-a...3456')
+    })
+  })
+})

--- a/tests/unit/apiKeyCrypto.test.ts
+++ b/tests/unit/apiKeyCrypto.test.ts
@@ -7,12 +7,19 @@ import {
 } from '../../src/helpers/apiKeyCrypto'
 
 describe('apiKeyCrypto', () => {
+  let originalSecret: string | undefined
+
   beforeEach(() => {
+    originalSecret = process.env.API_KEY_ENCRYPTION_SECRET
     process.env.API_KEY_ENCRYPTION_SECRET = 'test-encryption-secret'
   })
 
   afterEach(() => {
-    process.env.API_KEY_ENCRYPTION_SECRET = 'test-encryption-secret'
+    if (originalSecret === undefined) {
+      delete process.env.API_KEY_ENCRYPTION_SECRET
+    } else {
+      process.env.API_KEY_ENCRYPTION_SECRET = originalSecret
+    }
   })
 
   describe('encrypt / decrypt round-trip', () => {

--- a/tests/unit/quiz-submission.service.test.ts
+++ b/tests/unit/quiz-submission.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, vi, beforeEach, expect } from 'vitest'
+import { describe, it, vi, beforeEach, expect, type Mock } from 'vitest'
 
 import { AppError } from '../../src/helpers/AppError'
 import { scoreAnswers, submitQuiz } from '../../src/services/quiz-submission.service'
@@ -231,7 +231,7 @@ describe('submitQuiz duplicate-answer handling', () => {
     ])
 
     // Find the quiz_results insert payload (the object carrying the score).
-    const valuesFn = txMock.values as unknown as { mock: { calls: unknown[][] } }
+    const valuesFn = txMock.values as Mock
     const valuesCalls = valuesFn.mock.calls.map((c) => c[0])
     const scorePayload = valuesCalls.find(
       (v): v is { totalQuestions: number; correctAnswers: number; wrongAnswers: number } =>

--- a/tests/unit/quiz-submission.service.test.ts
+++ b/tests/unit/quiz-submission.service.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, vi, beforeEach, expect } from 'vitest'
+
+import { AppError } from '../../src/helpers/AppError'
+import { scoreAnswers, submitQuiz } from '../../src/services/quiz-submission.service'
+import type { QuestionType } from '../../src/types/questionTypes'
+
+type Question = { id: string; type: QuestionType }
+type Option = { id: string; questionId: string; isCorrect: boolean }
+
+// A thenable query-builder mock: every chained call returns the same builder,
+// and awaiting it resolves the next value queued in `selectResults` (in call
+// order). Lets us drive submitQuiz's sequential db.select(...) reads.
+const { dbMock, txMock, selectResults } = vi.hoisted(() => {
+  const selectResults: unknown[] = []
+  const resultRow = {
+    id: 'result-1',
+    totalQuestions: 0,
+    correctAnswers: 0,
+    wrongAnswers: 0,
+    gradingStatus: 'complete',
+  }
+
+  const builder: Record<string, unknown> = {}
+  const chain = () => builder
+  for (const m of ['select', 'from', 'where', 'limit', 'innerJoin', 'leftJoin', 'orderBy']) {
+    builder[m] = vi.fn(chain)
+  }
+  builder.then = (resolve: (value: unknown) => unknown) =>
+    resolve(selectResults.length > 0 ? selectResults.shift() : [])
+
+  const txMock: Record<string, unknown> = {}
+  txMock.insert = vi.fn(() => txMock)
+  txMock.values = vi.fn(() => txMock)
+  txMock.onConflictDoUpdate = vi.fn(() => Promise.resolve())
+  txMock.returning = vi.fn(() => Promise.resolve([resultRow]))
+  txMock.update = vi.fn(() => txMock)
+  txMock.set = vi.fn(() => txMock)
+  txMock.where = vi.fn(() => Promise.resolve())
+
+  const dbMock: Record<string, unknown> = {
+    select: vi.fn(chain),
+    transaction: vi.fn((cb: (tx: unknown) => unknown) => cb(txMock)),
+  }
+
+  return { dbMock, txMock, selectResults }
+})
+
+vi.mock('../../src/database/database', () => ({ db: dbMock }))
+// Avoid pulling the real LLM grader (and its clients) into this unit test.
+vi.mock('../../src/services/open-ended-grading.service', () => ({
+  gradeOpenEndedAnswers: vi.fn(),
+  gradeOpenEndedBatch: vi.fn(),
+}))
+
+describe('scoreAnswers', () => {
+  const emptyCorrectSets = new Map<string, Set<string>>()
+
+  it('should score every answer correct (all correct)', () => {
+    const questions: Question[] = [
+      { id: 'q1', type: 'multiple_choice' },
+      { id: 'q2', type: 'true_false' },
+    ]
+    const optionsById = new Map<string, Option>([
+      ['o1', { id: 'o1', questionId: 'q1', isCorrect: true }],
+      ['o2', { id: 'o2', questionId: 'q2', isCorrect: true }],
+    ])
+
+    const result = scoreAnswers(
+      questions,
+      [
+        { questionId: 'q1', selectedOptionId: 'o1' },
+        { questionId: 'q2', selectedOptionId: 'o2' },
+      ],
+      optionsById,
+      emptyCorrectSets,
+    )
+
+    expect(result.totalQuestions).toBe(2)
+    expect(result.correctAnswers).toBe(2)
+    expect(result.wrongAnswers).toBe(0)
+    expect(result.gradingStatus).toBe('complete')
+    expect(result.correctnessByQuestion.get('q1')).toBe(true)
+    expect(result.correctnessByQuestion.get('q2')).toBe(true)
+  })
+
+  it('should score every answer wrong (all wrong)', () => {
+    const questions: Question[] = [
+      { id: 'q1', type: 'multiple_choice' },
+      { id: 'q2', type: 'true_false' },
+    ]
+    const optionsById = new Map<string, Option>([
+      ['o1', { id: 'o1', questionId: 'q1', isCorrect: false }],
+      ['o2', { id: 'o2', questionId: 'q2', isCorrect: false }],
+    ])
+
+    const result = scoreAnswers(
+      questions,
+      [
+        { questionId: 'q1', selectedOptionId: 'o1' },
+        { questionId: 'q2', selectedOptionId: 'o2' },
+      ],
+      optionsById,
+      emptyCorrectSets,
+    )
+
+    expect(result.totalQuestions).toBe(2)
+    expect(result.correctAnswers).toBe(0)
+    expect(result.wrongAnswers).toBe(2)
+    expect(result.correctnessByQuestion.get('q1')).toBe(false)
+    expect(result.correctnessByQuestion.get('q2')).toBe(false)
+  })
+
+  it('should count open-ended toward the total but exclude it from the auto-score', () => {
+    const questions: Question[] = [
+      { id: 'q1', type: 'multiple_choice' },
+      { id: 'open', type: 'open_ended' },
+    ]
+    const optionsById = new Map<string, Option>([
+      ['o1', { id: 'o1', questionId: 'q1', isCorrect: true }],
+    ])
+
+    const result = scoreAnswers(
+      questions,
+      [
+        { questionId: 'q1', selectedOptionId: 'o1' },
+        { questionId: 'open', textAnswer: 'a thoughtful written answer' },
+      ],
+      optionsById,
+      emptyCorrectSets,
+    )
+
+    // open-ended is in the denominator but not auto-credited; it awaits grading.
+    expect(result.totalQuestions).toBe(2)
+    expect(result.correctAnswers).toBe(1)
+    expect(result.gradingStatus).toBe('pending')
+    // Open-ended is never marked correct by the synchronous scorer.
+    expect(result.correctnessByQuestion.has('open')).toBe(false)
+  })
+
+  it('should stay complete when an open-ended question is left unanswered', () => {
+    const questions: Question[] = [
+      { id: 'q1', type: 'multiple_choice' },
+      { id: 'open', type: 'open_ended' },
+    ]
+    const optionsById = new Map<string, Option>([
+      ['o1', { id: 'o1', questionId: 'q1', isCorrect: true }],
+    ])
+
+    const result = scoreAnswers(
+      questions,
+      [{ questionId: 'q1', selectedOptionId: 'o1' }],
+      optionsById,
+      emptyCorrectSets,
+    )
+
+    expect(result.totalQuestions).toBe(2)
+    expect(result.correctAnswers).toBe(1)
+    expect(result.gradingStatus).toBe('complete')
+  })
+
+  it('should require an exact set match for multi-select questions', () => {
+    const questions: Question[] = [{ id: 'q1', type: 'multi_select' }]
+    const optionsById = new Map<string, Option>([
+      ['o1', { id: 'o1', questionId: 'q1', isCorrect: true }],
+      ['o2', { id: 'o2', questionId: 'q1', isCorrect: true }],
+      ['o3', { id: 'o3', questionId: 'q1', isCorrect: false }],
+    ])
+    const correctSets = new Map<string, Set<string>>([['q1', new Set(['o1', 'o2'])]])
+
+    const exact = scoreAnswers(
+      questions,
+      [{ questionId: 'q1', selectedOptionIds: ['o1', 'o2'] }],
+      optionsById,
+      correctSets,
+    )
+    expect(exact.correctAnswers).toBe(1)
+    expect(exact.correctnessByQuestion.get('q1')).toBe(true)
+
+    const partial = scoreAnswers(
+      questions,
+      [{ questionId: 'q1', selectedOptionIds: ['o1'] }],
+      optionsById,
+      correctSets,
+    )
+    expect(partial.correctAnswers).toBe(0)
+    expect(partial.correctnessByQuestion.get('q1')).toBe(false)
+  })
+
+  it('should throw when a selected option does not belong to its question', () => {
+    const questions: Question[] = [{ id: 'q1', type: 'multiple_choice' }]
+    const optionsById = new Map<string, Option>([
+      ['o-other', { id: 'o-other', questionId: 'q2', isCorrect: true }],
+    ])
+
+    expect(() =>
+      scoreAnswers(
+        questions,
+        [{ questionId: 'q1', selectedOptionId: 'o-other' }],
+        optionsById,
+        emptyCorrectSets,
+      ),
+    ).toThrow(AppError)
+  })
+})
+
+describe('submitQuiz duplicate-answer handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    selectResults.length = 0
+  })
+
+  it('should keep only the first answer per question when duplicates are submitted', async () => {
+    const quizQuestions = [
+      { id: 'q1', type: 'multiple_choice' as QuestionType },
+      { id: 'q2', type: 'multiple_choice' as QuestionType },
+    ]
+    // After dedup, only optA (q1) and optC (q2) are referenced.
+    const optionRows = [
+      { id: 'optA', questionId: 'q1', isCorrect: true },
+      { id: 'optC', questionId: 'q2', isCorrect: true },
+    ]
+
+    // Queued in db read order: quiz lookup, questions, referenced options.
+    selectResults.push([{ id: 'quiz-1' }], quizQuestions, optionRows)
+
+    await submitQuiz('quiz-1', 'user-1', [
+      { questionId: 'q1', selectedOptionId: 'optA' },
+      // Duplicate for q1 — must be ignored. Counting it would double-score.
+      { questionId: 'q1', selectedOptionId: 'optA' },
+      { questionId: 'q2', selectedOptionId: 'optC' },
+    ])
+
+    // Find the quiz_results insert payload (the object carrying the score).
+    const valuesFn = txMock.values as unknown as { mock: { calls: unknown[][] } }
+    const valuesCalls = valuesFn.mock.calls.map((c) => c[0])
+    const scorePayload = valuesCalls.find(
+      (v): v is { totalQuestions: number; correctAnswers: number; wrongAnswers: number } =>
+        v != null && typeof v === 'object' && 'totalQuestions' in v,
+    )
+
+    expect(scorePayload).toBeDefined()
+    // 2 unique questions, both correct — the duplicate did not inflate the score.
+    expect(scorePayload!.totalQuestions).toBe(2)
+    expect(scorePayload!.correctAnswers).toBe(2)
+    expect(scorePayload!.wrongAnswers).toBe(0)
+  })
+})

--- a/tests/unit/quizLambdaUtils.test.ts
+++ b/tests/unit/quizLambdaUtils.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+
+import { normalizeQuestionType } from '../../src/helpers/utils/quizLambdaUtils'
+
+describe('normalizeQuestionType', () => {
+  it('should pass through canonical types', () => {
+    expect(normalizeQuestionType('multiple_choice')).toBe('multiple_choice')
+    expect(normalizeQuestionType('multi_select')).toBe('multi_select')
+    expect(normalizeQuestionType('true_false')).toBe('true_false')
+    expect(normalizeQuestionType('open_ended')).toBe('open_ended')
+  })
+
+  it('should lowercase and convert whitespace to underscores', () => {
+    expect(normalizeQuestionType('Multiple Choice')).toBe('multiple_choice')
+    expect(normalizeQuestionType('  MULTIPLE   CHOICE ')).toBe('multiple_choice')
+    expect(normalizeQuestionType('Multi Select')).toBe('multi_select')
+  })
+
+  it('should accept the slash form of true/false', () => {
+    expect(normalizeQuestionType('true/false')).toBe('true_false')
+    expect(normalizeQuestionType('True/False')).toBe('true_false')
+  })
+
+  it('should default to open_ended for undefined input', () => {
+    expect(normalizeQuestionType(undefined)).toBe('open_ended')
+  })
+
+  it('should default to open_ended for unrecognized values', () => {
+    expect(normalizeQuestionType('essay')).toBe('open_ended')
+    expect(normalizeQuestionType('')).toBe('open_ended')
+  })
+})


### PR DESCRIPTION
## Summary
  Completes the unit and integration test coverage requested in #46. The
  previous suite (PR #102) added a generic harness but missed every
  specifically-named target; this fills those gaps.

  ## Unit tests
  - **`scoreAnswers`** scoring edge cases: all correct, all wrong, open-ended
    excluded from the auto-score (counted toward the total but awaits grading →
    `gradingStatus: pending`), multi-select exact-set match, and a throw when a
    selected option doesn't belong to its question.
  - **`submitQuiz`** keeps only the first answer per question, so duplicate
    answers can't inflate the score (mocked db).
  - **`encryptApiKeyValue` / `decryptApiKeyValue`** round-trip, plus masking,
    invalid-format, and missing-secret cases.
  - **`normalizeQuestionType`** across canonical, spaced, slash, and unknown inputs.

  ## Integration tests (Supertest)
  - **`POST /quizzes/:id/submit`**: 200 scored result, 404 not found, and 400
    validation for duplicate `questionId` / an answer with no selection.
  - **`PATCH /quizzes/:id`**: quiz update — 200 / 404 / 400.

  ## Incidental fixes
  - analytics `dbMock` missing `leftJoin`
  - quiz integration `authMiddleware` mock missing `optionalAuthMiddleware`
  
  ## Testing
  - `npm test` → 55 passing across 13 files
  - ESLint, `tsc --noEmit`, and Prettier all clean
  
  ## How to run
  Unit + integration tests mock the db and external services, so they run offline
  (no DB or `.env` needed):

  ```bash
  
  npm test           # all unit + integration tests
  npm run test:unit  # only tests/unit
  npm run test:int   # only tests/integration
  npm run test:watch # watch mode (TDD)
  npm run test:coverage  # coverage report -> coverage/

  # a single file or filtered test
  npx vitest run tests/unit/apiKeyCrypto.test.ts
  npx vitest run tests/integration/quiz.test.ts -t submit