### PR TITLE
fix(analytics): break down pie chart by question type, not quiz type

### DIFF
--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -1,8 +1,8 @@
-import { and, eq } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 
 import { DEFAULT_MODEL } from '../constants/models'
 import { db } from '../database/database'
-import { folders, quizJobs, quizResults, quizzes } from '../database/schema'
+import { folders, questions, quizJobs, quizResults, quizzes } from '../database/schema'
 import { QUESTION_TYPES } from '../types/questionTypes'
 import type { QuestionType } from '../types/questionTypes'
 
@@ -15,7 +15,7 @@ export type ScorePoint = {
 
 export type TypeBreakdown = {
   type: QuestionType
-  quizCount: number
+  questionCount: number
 }
 
 export type QuizHistoryItem = {
@@ -85,7 +85,6 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
       createdAt: quizResults.createdAt,
       totalQuestions: quizResults.totalQuestions,
       correctAnswers: quizResults.correctAnswers,
-      quizType: quizzes.type,
       folderId: quizzes.folderId,
       folderName: folders.name,
     })
@@ -175,15 +174,31 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     }))
     .sort((a, b) => b.tokensUsed - a.tokensUsed)
 
+  // Breakdown by question type counts every question across all quizzes the
+  // user owns (taken or not), so a mixed-type quiz contributes to each type it
+  // actually contains rather than a single quiz-level bucket.
+  const questionTypeRows = await db
+    .select({ type: questions.type, count: sql<number>`count(*)::int` })
+    .from(questions)
+    .innerJoin(quizzes, eq(questions.quizId, quizzes.id))
+    .where(eq(quizzes.userId, userId))
+    .groupBy(questions.type)
+
+  const questionTypeCounts = new Map<QuestionType, number>(
+    questionTypeRows.map((row) => [row.type, row.count]),
+  )
   // Always send all 4 type slices so the pie chart can zero-fill empties.
-  const emptyTypeBreakdown: TypeBreakdown[] = QUESTION_TYPES.map((type) => ({ type, quizCount: 0 }))
+  const typeBreakdown: TypeBreakdown[] = QUESTION_TYPES.map((type) => ({
+    type,
+    questionCount: questionTypeCounts.get(type) ?? 0,
+  }))
 
   if (quizRows.length === 0) {
     return {
       totalQuizzesTaken: 0,
       averageScore: 0,
       scoreOverTime: [],
-      typeBreakdown: emptyTypeBreakdown,
+      typeBreakdown,
       folderStats: [
         {
           folderId: null,
@@ -219,7 +234,6 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
   // folderId may be null (root). Key the map by '' for null so it slots in cleanly.
   const folderAccs = new Map<string, FolderAcc>()
   const quizAccs = new Map<string, QuizAcc>()
-  const seenQuizTypes = new Map<string, QuestionType>()
 
   for (const r of quizRows) {
     if (r.totalQuestions <= 0) continue
@@ -267,23 +281,11 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     quizAcc.count += 1
     if (percent > quizAcc.best) quizAcc.best = percent
     quizAccs.set(r.quizId, quizAcc)
-
-    if (r.quizType) seenQuizTypes.set(r.quizId, r.quizType)
   }
 
   const averageScore = gradedCount > 0 ? gradedScoreSum / gradedCount : 0
 
   scoreOverTime.sort((a, b) => a.date.localeCompare(b.date))
-
-  // Count distinct quizzes per type so the pie reflects library composition.
-  const typeCounts = new Map<QuestionType, number>()
-  for (const type of seenQuizTypes.values()) {
-    typeCounts.set(type, (typeCounts.get(type) ?? 0) + 1)
-  }
-  const typeBreakdown: TypeBreakdown[] = QUESTION_TYPES.map((type) => ({
-    type,
-    quizCount: typeCounts.get(type) ?? 0,
-  }))
 
   const folderStats: FolderStat[] = [
     {

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -78,31 +78,44 @@ const toPercent = (correct: number, total: number) => (total > 0 ? (correct / to
 const round = (n: number) => Math.round(n * 100) / 100
 
 export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSummary> => {
-  const quizRows = await db
-    .select({
-      quizId: quizResults.quizId,
-      quizTitle: quizzes.title,
-      createdAt: quizResults.createdAt,
-      totalQuestions: quizResults.totalQuestions,
-      correctAnswers: quizResults.correctAnswers,
-      folderId: quizzes.folderId,
-      folderName: folders.name,
-    })
-    .from(quizResults)
-    .innerJoin(quizzes, eq(quizResults.quizId, quizzes.id))
-    .leftJoin(folders, eq(quizzes.folderId, folders.id))
-    .where(eq(quizResults.userId, userId))
+  // These three reads are independent, so run them concurrently rather than
+  // serializing the round-trips. `questionTypeRows` counts every question across
+  // all quizzes the user owns (taken or not), so a mixed-type quiz contributes
+  // to each type it contains rather than a single quiz-level bucket.
+  const [quizRows, tokenUsageRows, questionTypeRows] = await Promise.all([
+    db
+      .select({
+        quizId: quizResults.quizId,
+        quizTitle: quizzes.title,
+        createdAt: quizResults.createdAt,
+        totalQuestions: quizResults.totalQuestions,
+        correctAnswers: quizResults.correctAnswers,
+        folderId: quizzes.folderId,
+        folderName: folders.name,
+      })
+      .from(quizResults)
+      .innerJoin(quizzes, eq(quizResults.quizId, quizzes.id))
+      .leftJoin(folders, eq(quizzes.folderId, folders.id))
+      .where(eq(quizResults.userId, userId)),
 
-  const tokenUsageRows = await db
-    .select({
-      tokensUsed: quizJobs.tokensUsed,
-      apiKeyId: quizJobs.apiKeyId,
-      apiKeyName: quizJobs.apiKeyName,
-      properties: quizzes.properties,
-    })
-    .from(quizJobs)
-    .leftJoin(quizzes, eq(quizJobs.quizId, quizzes.id))
-    .where(and(eq(quizJobs.userId, userId), eq(quizJobs.status, 'done')))
+    db
+      .select({
+        tokensUsed: quizJobs.tokensUsed,
+        apiKeyId: quizJobs.apiKeyId,
+        apiKeyName: quizJobs.apiKeyName,
+        properties: quizzes.properties,
+      })
+      .from(quizJobs)
+      .leftJoin(quizzes, eq(quizJobs.quizId, quizzes.id))
+      .where(and(eq(quizJobs.userId, userId), eq(quizJobs.status, 'done'))),
+
+    db
+      .select({ type: questions.type, count: sql<number>`count(*)::int` })
+      .from(questions)
+      .innerJoin(quizzes, eq(questions.quizId, quizzes.id))
+      .where(eq(quizzes.userId, userId))
+      .groupBy(questions.type),
+  ])
 
   let totalTokensUsed = 0
   const keyMap = new Map<
@@ -173,16 +186,6 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
       percentage: totalTokensUsed > 0 ? round((m.tokens / totalTokensUsed) * 100) : 0,
     }))
     .sort((a, b) => b.tokensUsed - a.tokensUsed)
-
-  // Breakdown by question type counts every question across all quizzes the
-  // user owns (taken or not), so a mixed-type quiz contributes to each type it
-  // actually contains rather than a single quiz-level bucket.
-  const questionTypeRows = await db
-    .select({ type: questions.type, count: sql<number>`count(*)::int` })
-    .from(questions)
-    .innerJoin(quizzes, eq(questions.quizId, quizzes.id))
-    .where(eq(quizzes.userId, userId))
-    .groupBy(questions.type)
 
   const questionTypeCounts = new Map<QuestionType, number>(
     questionTypeRows.map((row) => [row.type, row.count]),

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -3,33 +3,37 @@ import { describe, it, vi, beforeEach } from 'vitest'
 
 import * as analyticsService from '../../src/services/analytics.service'
 
-const { dbMock } = vi.hoisted(() => {
-  const mock = {
-    select: vi.fn().mockReturnThis(),
-    from: vi.fn().mockReturnThis(),
-    innerJoin: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    then: vi.fn((resolve) => resolve([])),
+// A thenable query-builder mock: every chained call returns the builder, and
+// awaiting it resolves the next value queued in `queue` (in db-call order).
+// getAnalyticsSummary issues three reads: quiz results, token usage, then the
+// per-question-type counts.
+const { dbMock, queue } = vi.hoisted(() => {
+  const queue: unknown[] = []
+  const builder: Record<string, unknown> = {}
+  const chain = () => builder
+  for (const m of ['select', 'from', 'where', 'innerJoin', 'leftJoin', 'groupBy', 'orderBy']) {
+    builder[m] = vi.fn(chain)
   }
-  return { dbMock: mock }
+  builder.then = (resolve: (value: unknown) => unknown) =>
+    resolve(queue.length > 0 ? queue.shift() : [])
+  return { dbMock: builder, queue }
 })
 
-vi.mock('../../src/database/database', () => ({
-  db: dbMock,
-}))
+vi.mock('../../src/database/database', () => ({ db: dbMock }))
+
+const byType = (breakdown: Array<{ type: string; questionCount: number }>) =>
+  Object.fromEntries(breakdown.map((t) => [t.type, t.questionCount]))
 
 describe('AnalyticsService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    dbMock.select.mockReturnThis()
-    dbMock.from.mockReturnThis()
-    dbMock.innerJoin.mockReturnThis()
-    dbMock.where.mockReturnThis()
+    queue.length = 0
   })
 
   describe('getAnalyticsSummary', () => {
     it('should return empty summary when no quiz results exist', async () => {
-      dbMock.where.mockResolvedValueOnce([]).mockResolvedValueOnce([])
+      // quizRows, tokenUsageRows, questionTypeRows
+      queue.push([], [], [])
 
       const result = await analyticsService.getAnalyticsSummary('user-1')
       expect(result.totalQuizzesTaken).to.equal(0)
@@ -45,18 +49,66 @@ describe('AnalyticsService', () => {
           createdAt: new Date('2024-01-01'),
           totalQuestions: 10,
           correctAnswers: 8,
-          quizType: 'multiple_choice',
         },
       ]
       const mockTokenRows = [{ tokensUsed: { total_tokens: 100 } }]
 
-      dbMock.where.mockResolvedValueOnce(mockQuizRows).mockResolvedValueOnce(mockTokenRows)
+      queue.push(mockQuizRows, mockTokenRows, [])
 
       const result = await analyticsService.getAnalyticsSummary('user-1')
       expect(result.totalQuizzesTaken).to.equal(1)
       expect(result.averageScore).to.equal(80)
       expect(result.totalTokensUsed).to.equal(100)
       expect(result.history[0].quizTitle).to.equal('Quiz 1')
+    })
+
+    it('should count questions per type so a mixed quiz spans multiple slices', async () => {
+      const mockQuizRows = [
+        {
+          quizId: 'q-1',
+          quizTitle: 'Mixed Quiz',
+          createdAt: new Date('2024-01-01'),
+          totalQuestions: 10,
+          correctAnswers: 5,
+        },
+      ]
+      // One mixed quiz: 6 multiple-choice + 4 true/false questions.
+      const questionTypeRows = [
+        { type: 'multiple_choice', count: 6 },
+        { type: 'true_false', count: 4 },
+      ]
+
+      queue.push(mockQuizRows, [], questionTypeRows)
+
+      const result = await analyticsService.getAnalyticsSummary('user-1')
+      const counts = byType(result.typeBreakdown)
+
+      // The mixed quiz contributes to both type slices, not a single bucket.
+      expect(counts.multiple_choice).to.equal(6)
+      expect(counts.true_false).to.equal(4)
+      // All four types are always present, zero-filled.
+      expect(result.typeBreakdown).to.have.lengthOf(4)
+      expect(counts.multi_select).to.equal(0)
+      expect(counts.open_ended).to.equal(0)
+    })
+
+    it('should count questions from owned quizzes even when none were taken', async () => {
+      // No quiz results, but the user owns quizzes with questions.
+      const questionTypeRows = [
+        { type: 'multiple_choice', count: 3 },
+        { type: 'open_ended', count: 2 },
+      ]
+
+      queue.push([], [], questionTypeRows)
+
+      const result = await analyticsService.getAnalyticsSummary('user-1')
+      const counts = byType(result.typeBreakdown)
+
+      expect(result.totalQuizzesTaken).to.equal(0)
+      expect(counts.multiple_choice).to.equal(3)
+      expect(counts.open_ended).to.equal(2)
+      expect(counts.true_false).to.equal(0)
+      expect(counts.multi_select).to.equal(0)
     })
   })
 })


### PR DESCRIPTION
## Summary
  The "Breakdown by question type" pie wasn't reflecting mixed-type quizzes.
  It counted distinct quizzes by `quizzes.type` — a single nullable enum with
  no `mixed` value — so mixed quizzes (stored with `type = null`) were dropped
  entirely, and single-type quizzes were forced into one slice.

  ## Change
  Count **questions**, not quizzes: aggregate `questions.type` across **every
  quiz the user owns** (taken or not), grouped by type, so a mixed quiz
  contributes to each type it actually contains.

  - New question-type query in `getAnalyticsSummary` (computed before the
    empty-results early return, since the breakdown no longer depends on quiz
    results).
  - Removed the old `quizzes.type` / `seenQuizTypes` bucketing and the unused
    `quizType` select.
  - **Renamed `TypeBreakdown.quizCount` → `questionCount`** to match the new
    
  ## ⚠️  Breaking contract change
  `typeBreakdown[].quizCount` is now `questionCount`. The frontend reads the new
  field in companion PR `feat/mixed-questions-analytics` — **merge/deploy the two
  together (or backend first)** so the pie doesn't go empty in between.

  ## Tests
  - Rewrote `analytics.service.test.ts`: a mixed quiz spans multiple type slices,
    and questions from owned-but-untaken quizzes are still counted.
  - `npx vitest run tests/unit/analytics.service.test.ts` → 4/4 pass; `tsc --noEmit`
    and ESLint clean.

  Closes #104