### PR TITLE
Exclude mixed from analytics question-type breakdown

### DIFF
--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -190,11 +190,15 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
   const questionTypeCounts = new Map<QuestionType, number>(
     questionTypeRows.map((row) => [row.type, row.count]),
   )
-  // Always send all 4 type slices so the pie chart can zero-fill empties.
-  const typeBreakdown: TypeBreakdown[] = QUESTION_TYPES.map((type) => ({
-    type,
-    questionCount: questionTypeCounts.get(type) ?? 0,
-  }))
+  // Always send the real question-type slices so the pie chart can zero-fill
+  // empties. 'mixed' is a quiz-level type, never a question type, so it is
+  // excluded from the per-question breakdown.
+  const typeBreakdown: TypeBreakdown[] = QUESTION_TYPES.filter((type) => type !== 'mixed').map(
+    (type) => ({
+      type,
+      questionCount: questionTypeCounts.get(type) ?? 0,
+    }),
+  )
 
   if (quizRows.length === 0) {
     return {

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -270,7 +270,7 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     if (percent > allFolder.best) allFolder.best = percent
 
     const folderKey = r.folderId ?? ''
-    const folderName = r.folderId ? (r.folderName ?? 'Unnamed folder') : 'Root'
+    const folderName = r.folderId ? (r.folderName ?? 'Unnamed folder') : 'Unassigned'
     const folderAcc = folderAccs.get(folderKey) ?? { folderName, sum: 0, best: 0, count: 0 }
     folderAcc.sum += percent
     folderAcc.count += 1


### PR DESCRIPTION
The breakdown now counts by question type, and a question is never 'mixed' (that's a quiz-level type). Filter it out so the pie chart and legend show only the four real question types.