### PR TITLE
fix(analytics): scope question-type breakdown per folder

### DIFF
--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -219,14 +219,16 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
   // Always send the real question-type slices so the pie chart can zero-fill
   // empties. 'mixed' is a quiz-level type, never a question type, so it is
   // excluded from the per-question breakdown.
+  const allowedQuestionTypes = QUESTION_TYPES.filter((type) => type !== 'mixed')
   const buildTypeBreakdown = (counts: Map<QuestionType, number>): TypeBreakdown[] =>
-    QUESTION_TYPES.filter((type) => type !== 'mixed').map((type) => ({
+    allowedQuestionTypes.map((type) => ({
       type,
       questionCount: counts.get(type) ?? 0,
     }))
 
   const typeBreakdown: TypeBreakdown[] = buildTypeBreakdown(questionTypeCounts)
-  const typeBreakdownByFolder: FolderTypeBreakdown[] = Array.from(folderTypeCounts.entries()).map(
+  const typeBreakdownByFolder: FolderTypeBreakdown[] = Array.from(
+    folderTypeCounts,
     ([folderKey, counts]) => ({
       folderId: folderKey === '' ? null : folderKey,
       typeBreakdown: buildTypeBreakdown(counts),

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -18,6 +18,16 @@ export type TypeBreakdown = {
   questionCount: number
 }
 
+/**
+ * Per-folder question-type breakdown. `folderId` is the folder id, or null for
+ * quizzes with no folder ('Unassigned'). The all-quizzes rollup is the
+ * top-level `typeBreakdown` field, so it is intentionally absent here.
+ */
+export type FolderTypeBreakdown = {
+  folderId: string | null
+  typeBreakdown: TypeBreakdown[]
+}
+
 export type QuizHistoryItem = {
   quizId: string
   quizTitle: string
@@ -65,6 +75,7 @@ export type AnalyticsSummary = {
   averageScore: number
   scoreOverTime: ScorePoint[]
   typeBreakdown: TypeBreakdown[]
+  typeBreakdownByFolder: FolderTypeBreakdown[]
   folderStats: FolderStat[]
   quizStats: QuizStat[]
   history: QuizHistoryItem[]
@@ -110,11 +121,15 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
       .where(and(eq(quizJobs.userId, userId), eq(quizJobs.status, 'done'))),
 
     db
-      .select({ type: questions.type, count: sql<number>`count(*)::int` })
+      .select({
+        type: questions.type,
+        folderId: quizzes.folderId,
+        count: sql<number>`count(*)::int`,
+      })
       .from(questions)
       .innerJoin(quizzes, eq(questions.quizId, quizzes.id))
       .where(eq(quizzes.userId, userId))
-      .groupBy(questions.type),
+      .groupBy(questions.type, quizzes.folderId),
   ])
 
   let totalTokensUsed = 0
@@ -187,16 +202,34 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     }))
     .sort((a, b) => b.tokensUsed - a.tokensUsed)
 
-  const questionTypeCounts = new Map<QuestionType, number>(
-    questionTypeRows.map((row) => [row.type, row.count]),
-  )
+  // Roll the per-folder counts up into an all-quizzes total and keep a
+  // per-folder tally so the chart can scope to the selected folder. Folder key
+  // is the folder id, or '' for quizzes with no folder ('Unassigned').
+  const questionTypeCounts = new Map<QuestionType, number>()
+  const folderTypeCounts = new Map<string, Map<QuestionType, number>>()
+  for (const row of questionTypeRows) {
+    questionTypeCounts.set(row.type, (questionTypeCounts.get(row.type) ?? 0) + row.count)
+
+    const folderKey = row.folderId ?? ''
+    const folderCounts = folderTypeCounts.get(folderKey) ?? new Map<QuestionType, number>()
+    folderCounts.set(row.type, (folderCounts.get(row.type) ?? 0) + row.count)
+    folderTypeCounts.set(folderKey, folderCounts)
+  }
+
   // Always send the real question-type slices so the pie chart can zero-fill
   // empties. 'mixed' is a quiz-level type, never a question type, so it is
   // excluded from the per-question breakdown.
-  const typeBreakdown: TypeBreakdown[] = QUESTION_TYPES.filter((type) => type !== 'mixed').map(
-    (type) => ({
+  const buildTypeBreakdown = (counts: Map<QuestionType, number>): TypeBreakdown[] =>
+    QUESTION_TYPES.filter((type) => type !== 'mixed').map((type) => ({
       type,
-      questionCount: questionTypeCounts.get(type) ?? 0,
+      questionCount: counts.get(type) ?? 0,
+    }))
+
+  const typeBreakdown: TypeBreakdown[] = buildTypeBreakdown(questionTypeCounts)
+  const typeBreakdownByFolder: FolderTypeBreakdown[] = Array.from(folderTypeCounts.entries()).map(
+    ([folderKey, counts]) => ({
+      folderId: folderKey === '' ? null : folderKey,
+      typeBreakdown: buildTypeBreakdown(counts),
     }),
   )
 
@@ -206,6 +239,7 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
       averageScore: 0,
       scoreOverTime: [],
       typeBreakdown,
+      typeBreakdownByFolder,
       folderStats: [
         {
           folderId: null,
@@ -331,6 +365,7 @@ export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSumm
     averageScore: round(averageScore),
     scoreOverTime,
     typeBreakdown,
+    typeBreakdownByFolder,
     folderStats,
     quizStats,
     history,

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -110,5 +110,38 @@ describe('AnalyticsService', () => {
       expect(counts.true_false).to.equal(0)
       expect(counts.multi_select).to.equal(0)
     })
+
+    it('should break question types down per folder as well as overall', async () => {
+      // Two folders plus an unfoldered quiz, each contributing question types.
+      const questionTypeRows = [
+        { type: 'multiple_choice', folderId: 'folder-a', count: 5 },
+        { type: 'true_false', folderId: 'folder-a', count: 2 },
+        { type: 'open_ended', folderId: 'folder-b', count: 3 },
+        { type: 'multiple_choice', folderId: null, count: 4 },
+      ]
+
+      queue.push([], [], questionTypeRows)
+
+      const result = await analyticsService.getAnalyticsSummary('user-1')
+
+      // Overall rollup sums across every folder.
+      const all = byType(result.typeBreakdown)
+      expect(all.multiple_choice).to.equal(9)
+      expect(all.true_false).to.equal(2)
+      expect(all.open_ended).to.equal(3)
+
+      const byFolder = Object.fromEntries(
+        result.typeBreakdownByFolder.map((f) => [f.folderId ?? 'null', byType(f.typeBreakdown)]),
+      )
+
+      // Folder A: only its own questions, zero-filled for the rest.
+      expect(byFolder['folder-a'].multiple_choice).to.equal(5)
+      expect(byFolder['folder-a'].true_false).to.equal(2)
+      expect(byFolder['folder-a'].open_ended).to.equal(0)
+      // Folder B and the unfoldered ('null') bucket stay scoped to their quizzes.
+      expect(byFolder['folder-b'].open_ended).to.equal(3)
+      expect(byFolder['folder-b'].multiple_choice).to.equal(0)
+      expect(byFolder['null'].multiple_choice).to.equal(4)
+    })
   })
 })


### PR DESCRIPTION
The breakdown-by-question-type pie always counted questions across all quizzes, ignoring the folder selector. Group the question-type counts by folderId and emit a typeBreakdownByFolder rollup alongside the existing all-quizzes typeBreakdown so the chart can scope to the selected folder.

Closes frontend fix