### PR TITLE
feat: wire optionsPerQuestion through quiz generation pipeline

### DIFF
--- a/src/controllers/quizController.ts
+++ b/src/controllers/quizController.ts
@@ -48,6 +48,7 @@ export const generateQuizController = async (req: Request, res: Response, next: 
       difficulty,
       folderId,
       apiKeyId,
+      optionsPerQuestion,
     } = req.body as GenerateQuizInput
     if (source === 'notion') {
       if (!pageIds || pageIds.length === 0) {
@@ -67,6 +68,7 @@ export const generateQuizController = async (req: Request, res: Response, next: 
         apiKeyId,
         model,
         difficulty,
+        optionsPerQuestion,
       })
 
       return res.status(202).json(successResponse('Quiz generation started', result))
@@ -118,6 +120,7 @@ export const generateQuizController = async (req: Request, res: Response, next: 
       difficulty,
       folderId,
       apiKeyId,
+      optionsPerQuestion,
     })
 
     return res.status(202).json(

--- a/src/lambda/quizGenerator.ts
+++ b/src/lambda/quizGenerator.ts
@@ -33,6 +33,7 @@ type LambdaEvent = {
   timerDuration?: number
   type?: string
   questionCount?: number
+  optionsPerQuestion?: number
   model?: string
   quiz?: AiQuiz
   userBio?: string | null
@@ -151,6 +152,7 @@ export const handler = async (event: LambdaEvent) => {
           model: event.model,
           difficulty: event.difficulty,
           apiKey,
+          optionsPerQuestion: event.optionsPerQuestion,
         })
 
     const quizRow = await persistQuiz(result, event, {

--- a/src/prompts/quiz-generation.prompt.ts
+++ b/src/prompts/quiz-generation.prompt.ts
@@ -20,7 +20,9 @@ export const buildQuizSystemPrompt = (
   count: number,
   userBio?: string | null,
   difficulty?: DifficultyType,
+  optionsPerQuestion?: number,
 ) => {
+  const optionCount = optionsPerQuestion ?? 4
   const typeRule =
     type && type !== 'mixed'
       ? 'Every question MUST be of type "' + type + '".'
@@ -35,9 +37,10 @@ export const buildQuizSystemPrompt = (
     typeRule,
     '',
     '## Question type constraints',
-    '- "multiple_choice": 4 options, exactly one isCorrect=true.',
-    '- "multi_select": 4–5 options, two or more isCorrect=true.',
-    '- "true_false": exactly two options with the text "True" and "False", exactly one isCorrect=true.',
+    `- "multiple_choice": exactly ${optionCount} options, exactly one isCorrect=true.`,
+    `- "multi_select": exactly ${optionCount} options, two or more isCorrect=true. ALWAYS exactly ${optionCount} options — never more, never fewer.`,
+    `- For mixed quizzes: only "multiple_choice" and "multi_select" questions use exactly ${optionCount} options. "true_false" always uses exactly 2, "open_ended" always uses exactly 1.`,
+    '- "true_false": ALWAYS exactly two options with the text "True" and "False" — never more, never fewer, regardless of any other setting. Exactly one isCorrect=true.',
     '- "open_ended": exactly one option whose text is a concise model answer (2–4 sentences). isCorrect=true. The explanation should describe what key points a complete answer must cover.',
     '',
     '## Question quality',

--- a/src/services/helpers/invokeQuizGenerator.ts
+++ b/src/services/helpers/invokeQuizGenerator.ts
@@ -18,6 +18,7 @@ export type QuizGeneratePayload = {
   timerDuration?: number
   type?: QuestionType
   questionCount?: number
+  optionsPerQuestion?: number
   model?: string
   userBio?: string | null
   difficulty?: DifficultyType

--- a/src/services/helpers/quizAi.ts
+++ b/src/services/helpers/quizAi.ts
@@ -43,6 +43,7 @@ type GenerateOptions = {
   userBio?: string | null
   difficulty?: DifficultyType
   apiKey?: string
+  optionsPerQuestion?: number
 }
 
 const buildSchema = (type?: QuestionType) => ({
@@ -100,6 +101,7 @@ export const generateQuizFromText = async ({
   userBio,
   difficulty,
   apiKey,
+  optionsPerQuestion,
 }: GenerateOptions): Promise<AiQuizResult> => {
   const count =
     questionCount && questionCount > 0 ? Math.min(questionCount, 30) : DEFAULT_QUESTION_COUNT
@@ -152,6 +154,10 @@ export const generateQuizFromText = async ({
     messages: [
       { role: 'system', content: buildQuizSystemPrompt(type, count, userBio, difficulty) },
       { role: 'user', content },
+      {
+        role: 'system',
+        content: buildQuizSystemPrompt(type, count, userBio, difficulty, optionsPerQuestion),
+      },
     ],
   })
 

--- a/src/services/helpers/quizAi.ts
+++ b/src/services/helpers/quizAi.ts
@@ -156,7 +156,14 @@ export const generateQuizFromText = async ({
     messages: [
       {
         role: 'system',
-        content: buildQuizSystemPrompt(type, count, userBio, difficulty, avoidQuestions),
+        content: buildQuizSystemPrompt(
+          type,
+          count,
+          userBio,
+          difficulty,
+          optionsPerQuestion,
+          avoidQuestions,
+        ),
       },
       { role: 'user', content },
       {

--- a/src/services/notion-quiz.service.ts
+++ b/src/services/notion-quiz.service.ts
@@ -18,6 +18,7 @@ export type GenerateQuizFromNotionInput = {
   timerDuration?: number
   type?: QuestionType
   questionCount?: number
+  optionsPerQuestion?: number
   folderId?: string
   apiKeyId?: string
   model?: string
@@ -89,6 +90,7 @@ class NotionQuizService {
         apiKeyId: input.apiKeyId,
         difficulty: input.difficulty,
         model: input.model,
+        optionsPerQuestion: input.optionsPerQuestion,
       })
 
       return {

--- a/src/validators/quiz.schema.ts
+++ b/src/validators/quiz.schema.ts
@@ -53,6 +53,7 @@ export const GenerateQuizSchema = z
     type: QuestionTypeEnum.optional(),
 
     questionCount: z.coerce.number().int().min(1).max(30).optional(),
+    optionsPerQuestion: z.coerce.number().int().min(2).max(6).optional(),
 
     /** AI model to use for quiz generation. */
     model: z.enum(SUPPORTED_MODELS as unknown as [string, ...string[]]).optional(),
@@ -174,6 +175,7 @@ export const GenerateQuizFromNotionSchema = z
     type: QuestionTypeEnum.optional(),
 
     questionCount: z.coerce.number().int().min(1).max(30).optional(),
+    optionsPerQuestion: z.coerce.number().int().min(2).max(6).optional(),
 
     folderId: z.uuid().optional(),
     apiKeyId: z.uuid().optional(),


### PR DESCRIPTION
## Summary
Minimal backend changes to support the `optionsPerQuestion` field sent by the frontend.
The value flows from the API request all the way to the AI prompt.

## Changes

**`src/validators/quiz.schema.ts`**
- Added `optionsPerQuestion: z.coerce.number().int().min(2).max(6).optional()` to `GenerateQuizSchema` and `GenerateQuizFromNotionSchema`

**`src/controllers/quizController.ts`**
- Extracted `optionsPerQuestion` from `req.body`
- Forwarded to both `invokeQuizGenerator` (file) and `notionQuizService` (Notion)

**`src/services/notion-quiz.service.ts`**
- Added `optionsPerQuestion?: number` to `GenerateQuizFromNotionInput`
- Forwarded to `invokeQuizGenerator`

**`src/services/helpers/invokeQuizGenerator.ts`**
- Added `optionsPerQuestion?: number` to `QuizGeneratePayload`
- Automatically forwarded to Lambda via `...payload` spread

**`src/lambda/quizGenerator.ts`**
- Added `optionsPerQuestion?: number` to `LambdaEvent`
- Forwarded to `generateQuizFromText`

**`src/services/helpers/quizAi.ts`**
- Added `optionsPerQuestion?: number` to `GenerateOptions`
- Passed to `buildQuizSystemPrompt` as 5th argument

**`src/prompts/quiz-generation.prompt.ts`**
- Added `optionsPerQuestion` parameter with default of `4`
- `multiple_choice` and `multi_select` now use dynamic `optionCount`
- `true_false` explicitly hardcoded to always use exactly 2 options

## ⚠️ Important
Lambda must be redeployed after merging:
```bash
npm run deploy:lambda
```

## Related PR
Frontend changes: `QuizFlow-frontend#81