### PR TITLE
feat: implement debounced folder search in move to folder section and quiz search in new folder section

### DIFF
--- a/src/controllers/folderController.ts
+++ b/src/controllers/folderController.ts
@@ -13,7 +13,7 @@ import {
 
 export const getFolders = async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-const search = typeof req.query.search === 'string' ? req.query.search : undefined
+    const search = typeof req.query.search === 'string' ? req.query.search : undefined
     const folders = await folderService.getFolders(req.user!.id, search)
     return res.json(successResponse('Folders retrieved', folders))
   } catch (error) {

--- a/src/controllers/folderController.ts
+++ b/src/controllers/folderController.ts
@@ -13,7 +13,8 @@ import {
 
 export const getFolders = async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-    const folders = await folderService.getFolders(req.user!.id)
+    const search = req.query.search as string | undefined
+    const folders = await folderService.getFolders(req.user!.id, search)
     return res.json(successResponse('Folders retrieved', folders))
   } catch (error) {
     next(error)

--- a/src/controllers/folderController.ts
+++ b/src/controllers/folderController.ts
@@ -13,7 +13,7 @@ import {
 
 export const getFolders = async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-    const search = req.query.search as string | undefined
+const search = typeof req.query.search === 'string' ? req.query.search : undefined
     const folders = await folderService.getFolders(req.user!.id, search)
     return res.json(successResponse('Folders retrieved', folders))
   } catch (error) {

--- a/src/services/folder.service.ts
+++ b/src/services/folder.service.ts
@@ -3,7 +3,13 @@ import { and, eq, sql, inArray } from 'drizzle-orm'
 import { db } from '../database/database'
 import { folders, quizzes } from '../database/schema'
 
-export const getFolders = async (userId: string) => {
+export const getFolders = async (userId: string, search?: string) => {
+  const conditions = [eq(folders.userId, userId)]
+
+  if (search?.trim()) {
+    conditions.push(sql`lower(${folders.name}) like ${'%' + search.toLowerCase() + '%'}`)
+  }
+
   const userFolders = await db
     .select({
       id: folders.id,
@@ -14,7 +20,7 @@ export const getFolders = async (userId: string) => {
     })
     .from(folders)
     .leftJoin(quizzes, eq(quizzes.folderId, folders.id))
-    .where(eq(folders.userId, userId))
+    .where(and(...conditions))
     .groupBy(folders.id)
     .orderBy(folders.name)
 


### PR DESCRIPTION
## Summary

- Add debounced search for folder selection modals
- Move folder filtering from the frontend to the backend
- Add backend search support using ILIKE
- Reduce unnecessary client-side filtering and improve performance

## Backend
- Add optional `search` parameter to `getFolders`
- Apply `ILIKE` filter when search is provided
- Pass `search` query parameter from the controller

Closes mirzakhalov03/QuizFlow-frontend#109