### PR TITLE
feat(analytics): cache summary in Redis with 3h TTL (#122)

### DIFF
--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -91,7 +91,15 @@ const round = (n: number) => Math.round(n * 100) / 100
 
 // Analytics recomputes several joins + in-memory rollups on every page load, so
 // we cache the result per user. Default 3h TTL; invalidated eagerly on new attempts.
-const ANALYTICS_CACHE_TTL_SECONDS = Number(process.env.ANALYTICS_CACHE_TTL_SECONDS) || 3 * 60 * 60
+// Parse the override strictly: Redis `EX` needs a positive integer, so a missing,
+// non-numeric, float, or non-positive value falls back to the default rather than
+// handing Redis a NaN/float it would reject.
+const DEFAULT_ANALYTICS_CACHE_TTL_SECONDS = 3 * 60 * 60
+const parsedCacheTtl = parseInt(process.env.ANALYTICS_CACHE_TTL_SECONDS ?? '', 10)
+const ANALYTICS_CACHE_TTL_SECONDS =
+  Number.isInteger(parsedCacheTtl) && parsedCacheTtl > 0
+    ? parsedCacheTtl
+    : DEFAULT_ANALYTICS_CACHE_TTL_SECONDS
 
 const analyticsCacheKey = (userId: string) => `analytics:summary:${userId}`
 

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -1,5 +1,6 @@
 import { and, eq, sql } from 'drizzle-orm'
 
+import { cacheDel, cacheGetJson, cacheSetJson } from './clients/redis.client'
 import { DEFAULT_MODEL } from '../constants/models'
 import { db } from '../database/database'
 import { folders, questions, quizJobs, quizResults, quizzes } from '../database/schema'
@@ -88,7 +89,28 @@ const toPercent = (correct: number, total: number) => (total > 0 ? (correct / to
 
 const round = (n: number) => Math.round(n * 100) / 100
 
+// Analytics recomputes several joins + in-memory rollups on every page load, so
+// we cache the result per user. Default 3h TTL; invalidated eagerly on new attempts.
+const ANALYTICS_CACHE_TTL_SECONDS = Number(process.env.ANALYTICS_CACHE_TTL_SECONDS) || 3 * 60 * 60
+
+const analyticsCacheKey = (userId: string) => `analytics:summary:${userId}`
+
+/** Drop a user's cached analytics so their next read recomputes (e.g. after a new attempt). */
+export const invalidateAnalyticsCache = (userId: string): Promise<void> =>
+  cacheDel(analyticsCacheKey(userId))
+
 export const getAnalyticsSummary = async (userId: string): Promise<AnalyticsSummary> => {
+  const cacheKey = analyticsCacheKey(userId)
+
+  const cached = await cacheGetJson<AnalyticsSummary>(cacheKey)
+  if (cached) return cached
+
+  const summary = await computeAnalyticsSummary(userId)
+  await cacheSetJson(cacheKey, summary, ANALYTICS_CACHE_TTL_SECONDS)
+  return summary
+}
+
+const computeAnalyticsSummary = async (userId: string): Promise<AnalyticsSummary> => {
   // These three reads are independent, so run them concurrently rather than
   // serializing the round-trips. `questionTypeRows` counts every question across
   // all quizzes the user owns (taken or not), so a mixed-type quiz contributes

--- a/src/services/clients/redis.client.ts
+++ b/src/services/clients/redis.client.ts
@@ -73,6 +73,45 @@ const getRedisClient = async (): Promise<RedisClient> => {
   }
 }
 
+/**
+ * Read a JSON-serialized value from the cache. Fails open: on a miss, a parse
+ * error, or an unreachable Redis, returns null so callers recompute from source.
+ */
+export const cacheGetJson = async <T>(key: string): Promise<T | null> => {
+  try {
+    const redis = await getRedisClient()
+    const raw = await redis.get(key)
+    return raw ? (JSON.parse(raw) as T) : null
+  } catch (err) {
+    logger.warn('Redis cache read failed, falling back to source', { key, error: errText(err) })
+    return null
+  }
+}
+
+/** Write a JSON-serialized value with a TTL. Fails open — a write miss just means a later recompute. */
+export const cacheSetJson = async (
+  key: string,
+  value: unknown,
+  ttlSeconds: number,
+): Promise<void> => {
+  try {
+    const redis = await getRedisClient()
+    await redis.set(key, JSON.stringify(value), { EX: ttlSeconds })
+  } catch (err) {
+    logger.warn('Redis cache write failed', { key, error: errText(err) })
+  }
+}
+
+/** Delete a cached key so the next read recomputes. Fails open — TTL is the backstop. */
+export const cacheDel = async (key: string): Promise<void> => {
+  try {
+    const redis = await getRedisClient()
+    await redis.del(key)
+  } catch (err) {
+    logger.warn('Redis cache delete failed, relying on TTL', { key, error: errText(err) })
+  }
+}
+
 const lockKey = (userId: string): string => `feedback:lock:${userId}`
 
 /**

--- a/src/services/clients/redis.client.ts
+++ b/src/services/clients/redis.client.ts
@@ -81,7 +81,18 @@ export const cacheGetJson = async <T>(key: string): Promise<T | null> => {
   try {
     const redis = await getRedisClient()
     const raw = await redis.get(key)
-    return raw ? (JSON.parse(raw) as T) : null
+    if (!raw) return null
+    try {
+      return JSON.parse(raw) as T
+    } catch (err) {
+      // Corrupt entry: evict it so we don't recompute + warn on every read until TTL.
+      await redis.del(key).catch(() => {})
+      logger.warn('Redis cache contained invalid JSON, evicting and falling back to source', {
+        key,
+        error: errText(err),
+      })
+      return null
+    }
   } catch (err) {
     logger.warn('Redis cache read failed, falling back to source', { key, error: errText(err) })
     return null
@@ -94,6 +105,12 @@ export const cacheSetJson = async (
   value: unknown,
   ttlSeconds: number,
 ): Promise<void> => {
+  // Redis EX requires a positive integer; skip rather than let a misconfigured TTL
+  // throw and warn on every write.
+  if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+    logger.warn('Redis cache write skipped due to invalid TTL', { key, ttlSeconds })
+    return
+  }
   try {
     const redis = await getRedisClient()
     await redis.set(key, JSON.stringify(value), { EX: ttlSeconds })

--- a/src/services/quiz-submission.service.ts
+++ b/src/services/quiz-submission.service.ts
@@ -307,6 +307,11 @@ export const submitQuiz = async (
   if (gradingStatus === 'pending') {
     await gradeOpenEndedAnswers(result.id, quizId, userId)
 
+    // Grading rewrote correctAnswers/status on this row. The invalidation above ran
+    // pre-grading, so a concurrent read could have recached the partial totals —
+    // drop it again now that the attempt is finalized.
+    await invalidateAnalyticsCache(userId)
+
     const [finalized] = await db
       .select()
       .from(quizResults)
@@ -562,6 +567,10 @@ export const submitPublicQuiz = async (
         gradingStatus,
       })
     })
+
+    // This attempt counts toward the logged-in taker's analytics — drop their
+    // cache so the next dashboard load reflects it (mirrors submitQuiz).
+    await invalidateAnalyticsCache(userId)
   }
 
   return { name, totalQuestions, correctAnswers, wrongAnswers, review }

--- a/src/services/quiz-submission.service.ts
+++ b/src/services/quiz-submission.service.ts
@@ -1,5 +1,6 @@
 import { and, desc, eq, inArray, or, sql } from 'drizzle-orm'
 
+import { invalidateAnalyticsCache } from './analytics.service'
 import { incrementPlayCount } from './marketplace.service'
 import {
   gradeOpenEndedAnswers,
@@ -287,6 +288,10 @@ export const submitQuiz = async (
   })
 
   logger.info('Quiz submitted successfully', { quizId, userId, resultId: result.id })
+
+  // A new attempt makes this user's cached analytics stale — drop it so their
+  // next dashboard load recomputes instead of waiting out the TTL.
+  await invalidateAnalyticsCache(userId)
 
   // Bump marketplace play count for non-owner takes (mirrors the public-submit path).
   if (quiz.userId !== userId) {

--- a/tests/unit/analytics.service.test.ts
+++ b/tests/unit/analytics.service.test.ts
@@ -19,7 +19,16 @@ const { dbMock, queue } = vi.hoisted(() => {
   return { dbMock: builder, queue }
 })
 
+const { cacheMock } = vi.hoisted(() => ({
+  cacheMock: {
+    cacheGetJson: vi.fn(),
+    cacheSetJson: vi.fn(),
+    cacheDel: vi.fn(),
+  },
+}))
+
 vi.mock('../../src/database/database', () => ({ db: dbMock }))
+vi.mock('../../src/services/clients/redis.client', () => cacheMock)
 
 const byType = (breakdown: Array<{ type: string; questionCount: number }>) =>
   Object.fromEntries(breakdown.map((t) => [t.type, t.questionCount]))
@@ -28,6 +37,10 @@ describe('AnalyticsService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     queue.length = 0
+    // Default to a cache miss so the compute path runs; individual tests override.
+    cacheMock.cacheGetJson.mockResolvedValue(null)
+    cacheMock.cacheSetJson.mockResolvedValue(undefined)
+    cacheMock.cacheDel.mockResolvedValue(undefined)
   })
 
   describe('getAnalyticsSummary', () => {
@@ -142,6 +155,31 @@ describe('AnalyticsService', () => {
       expect(byFolder['folder-b'].open_ended).to.equal(3)
       expect(byFolder['folder-b'].multiple_choice).to.equal(0)
       expect(byFolder['null'].multiple_choice).to.equal(4)
+    })
+  })
+
+  describe('getAnalyticsSummary caching', () => {
+    it('returns the cached summary and skips recomputation on a cache hit', async () => {
+      const cached = { totalQuizzesTaken: 7, averageScore: 42 }
+      cacheMock.cacheGetJson.mockResolvedValueOnce(cached)
+
+      const result = await analyticsService.getAnalyticsSummary('user-1')
+
+      expect(result).to.equal(cached)
+      // Cache hit short-circuits: no DB reads, and we don't rewrite the cache.
+      expect(dbMock.select.mock.calls).to.have.lengthOf(0)
+      expect(cacheMock.cacheSetJson.mock.calls).to.have.lengthOf(0)
+    })
+
+    it('recomputes and caches when Redis is unavailable or holds no value', async () => {
+      // cacheGetJson fails open to null (miss / read error / malformed JSON).
+      cacheMock.cacheGetJson.mockResolvedValueOnce(null)
+      queue.push([], [], [])
+
+      const result = await analyticsService.getAnalyticsSummary('user-1')
+
+      expect(result.totalQuizzesTaken).to.equal(0)
+      expect(cacheMock.cacheSetJson.mock.calls).to.have.lengthOf(1)
     })
   })
 })


### PR DESCRIPTION
Cache getAnalyticsSummary per user via the existing redis.client, with a configurable TTL (ANALYTICS_CACHE_TTL_SECONDS, default 3h) and eager invalidation on new attempts in submitQuiz. Fails open when Redis is unavailable so analytics still computes from Postgres.