### PR TITLE
feat(history): add page/offset paging with total count

### DIFF
--- a/src/services/history.service.ts
+++ b/src/services/history.service.ts
@@ -29,12 +29,14 @@ export const getQuizHistory = async (
   userId: string,
   { folderId, limit, page, sort }: HistoryQuery,
 ): Promise<HistoryResponse> => {
+  // Trailing id keeps the sort a total order: createdAt (and score) can tie, and
+  // offset paging duplicates/drops rows unless every ordering is deterministic.
   const orderBy =
     sort === 'best'
-      ? [desc(scoreExpr), desc(quizResults.createdAt)]
+      ? [desc(scoreExpr), desc(quizResults.createdAt), desc(quizResults.id)]
       : sort === 'worst'
-        ? [asc(scoreExpr), desc(quizResults.createdAt)]
-        : [desc(quizResults.createdAt)]
+        ? [asc(scoreExpr), desc(quizResults.createdAt), desc(quizResults.id)]
+        : [desc(quizResults.createdAt), desc(quizResults.id)]
 
   const where = and(
     eq(quizResults.userId, userId),

--- a/src/services/history.service.ts
+++ b/src/services/history.service.ts
@@ -18,13 +18,16 @@ export type HistoryItem = {
 
 export type HistoryResponse = {
   items: HistoryItem[]
+  total: number
+  page: number
+  limit: number
 }
 
 const scoreExpr = sql<number>`(${quizResults.correctAnswers}::float / NULLIF(${quizResults.totalQuestions}, 0)) * 100`
 
 export const getQuizHistory = async (
   userId: string,
-  { folderId, limit, sort }: HistoryQuery,
+  { folderId, limit, page, sort }: HistoryQuery,
 ): Promise<HistoryResponse> => {
   const orderBy =
     sort === 'best'
@@ -32,6 +35,14 @@ export const getQuizHistory = async (
       : sort === 'worst'
         ? [asc(scoreExpr), desc(quizResults.createdAt)]
         : [desc(quizResults.createdAt)]
+
+  const where = and(
+    eq(quizResults.userId, userId),
+    gt(quizResults.totalQuestions, 0),
+    folderId ? eq(quizzes.folderId, folderId) : undefined,
+  )
+
+  const offset = (page - 1) * limit
 
   const rows = await db
     .select({
@@ -48,15 +59,16 @@ export const getQuizHistory = async (
     .from(quizResults)
     .innerJoin(quizzes, eq(quizResults.quizId, quizzes.id))
     .leftJoin(folders, eq(quizzes.folderId, folders.id))
-    .where(
-      and(
-        eq(quizResults.userId, userId),
-        gt(quizResults.totalQuestions, 0),
-        folderId ? eq(quizzes.folderId, folderId) : undefined,
-      ),
-    )
+    .where(where)
     .orderBy(...orderBy)
     .limit(limit)
+    .offset(offset)
+
+  const [{ total }] = await db
+    .select({ total: sql<number>`count(*)::int` })
+    .from(quizResults)
+    .innerJoin(quizzes, eq(quizResults.quizId, quizzes.id))
+    .where(where)
 
   const items: HistoryItem[] = rows.map((r) => ({
     resultId: r.resultId,
@@ -70,5 +82,5 @@ export const getQuizHistory = async (
     completedAt: r.completedAt.toISOString(),
   }))
 
-  return { items }
+  return { items, total, page, limit }
 }

--- a/src/validators/history.schema.ts
+++ b/src/validators/history.schema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 export const HistoryQuerySchema = z.object({
   /** Folder UUID, or omitted to return history across all folders. */
   folderId: z.string().uuid().optional(),
-  /** How many attempts to return. */
+  /** Page size. */
   limit: z.coerce
     .number()
     .int()
@@ -11,6 +11,8 @@ export const HistoryQuerySchema = z.object({
       message: 'limit must be 5, 10, or 50',
     })
     .default(10),
+  /** 1-based page number. */
+  page: z.coerce.number().int().min(1).default(1),
   /** Ordering: most recent first, highest score first, or lowest score first. */
   sort: z.enum(['recent', 'best', 'worst']).default('recent'),
 })


### PR DESCRIPTION
Adds true pagination to the quiz history endpoint (`GET /history`). Previously
`limit` was a top-N cap (5/10/50) with no way to page through older attempts and
no total count. Now the endpoint accepts a `page` param and returns paging metadata.

## Changes
- `history.schema.ts`: new `page` query param — 1-based integer, defaults to `1`.
  `limit` (5/10/50) is retained and now acts as the page size.
- `history.service.ts`:
  - Applies `offset = (page - 1) * limit` to the results query.
  - Runs a `count(*)` query with the same WHERE clause to get the total.
  - Response is now `{ items, total, page, limit }` (was `{ items }`).

## API
`GET /history?folderId=&limit=10&page=2&sort=recent`

```json
{
  "items": [ ... ],
  "total": 137,
  "page": 2,
  "limit": 10
}

Notes

- limit validation unchanged (must be 5, 10, or 50).
- Pairs with the frontend PR feat/history-pagination-113.

Testing

- tsc --noEmit clean.
- Full unit suite green (117 tests).